### PR TITLE
Update DApps query filtering

### DIFF
--- a/apps/rollups/graphql/subgraph/rollups.graphql
+++ b/apps/rollups/graphql/subgraph/rollups.graphql
@@ -15,9 +15,6 @@ query dapps(
         inputCount
         deploymentTimestamp
         activityTimestamp
-        factory {
-            id
-        }
     }
 }
 

--- a/apps/rollups/src/containers/rollups/Dapps.tsx
+++ b/apps/rollups/src/containers/rollups/Dapps.tsx
@@ -37,6 +37,7 @@ import {
 import { FC, useState } from 'react';
 import { DAppsList } from '../../components/DAppsList';
 import {
+    DAppStatus,
     DApp_OrderBy,
     useDappsQuery,
     useDashboardQuery,
@@ -174,13 +175,20 @@ export const Dapps: FC<DappsProps> = (props) => {
         DApp_OrderBy.ActivityTimestamp
     );
     const perPage = 10;
+
+    const status = DAppStatus.CreatedByFactory;
     const [dAppsResult] = useDappsQuery({
         variables: {
             orderBy,
             first: perPage,
             skip: perPage * pageNumber,
             where_dapp:
-                search && search.length > 0 ? { id: search } : undefined,
+                search && search.length > 0
+                    ? {
+                          id: search,
+                          status,
+                      }
+                    : { status },
         },
     });
     const [dashboardResult] = useDashboardQuery({

--- a/apps/rollups/tsconfig.json
+++ b/apps/rollups/tsconfig.json
@@ -7,7 +7,7 @@
     },
     "compilerOptions": {
         "strict": false,
-        "isolatedModules": false
+        "isolatedModules": true
     },
     "exclude": ["node_modules"],
     "include": [


### PR DESCRIPTION
## Summary
We change the backend to handle the case of inputs targeting DApps that were not yet "instantiated", more details [here](https://github.com/cartesi/subgraph/issues/12). So the changes are to improve the filtering to avoid listing non-existing DApps. Also did a small clean-up of unused properties in the query.
