### PR TITLE
Chore: Update GA for rollups docker image publishing

### DIFF
--- a/.github/workflows/docker-rollups.yml
+++ b/.github/workflows/docker-rollups.yml
@@ -5,21 +5,29 @@ on:
             - 'apps/rollups/**'
             - 'packages/**'
     push:
+        paths:
+            - 'apps/rollups/**'
+            - 'packages/**'
+        branches:
+            - main 
         tags:
-            - v*
-env:
-    image_name: rollups-explorer
+            - rollups@*
+
+permissions:
+    packages: write
+    contents: read
 
 concurrency:
     group: ${{github.workflow}}-${{github.ref_name}}
     cancel-in-progress: true
 
+env:
+    image_name: rollups-explorer
+    push_to_dockerhub: ${{startsWith(github.ref, 'refs/tags/rollups@')}}
+
 jobs:
     build:
         runs-on: ubuntu-latest
-        permissions:
-            packages: write
-            contents: read
         steps:
             - name: Check out code
               uses: actions/checkout@v3
@@ -40,7 +48,7 @@ jobs:
               run: yarn lint
 
             - name: Run Tests
-              run: yarn test:ci
+              run: yarn test
 
             - name: Set Up QEMU
               uses: docker/setup-qemu-action@v2
@@ -55,16 +63,18 @@ jobs:
               with:
                   images: |
                       name=ghcr.io/${{ github.repository_owner }}/${{ env.image_name }}
-                      name=docker.io/${{ github.repository_owner }}/${{ env.image_name }},enable=${{ github.repository_owner == 'cartesi' }}
+                      name=docker.io/${{ github.repository_owner }}/${{ env.image_name }},enable=${{ env.push_to_dockerhub }}
                   tags: |
-                      type=semver,pattern={{version}}
-                      type=ref,event=branch
+                      type=match,pattern=rollups@(.*),group=1
+                      type=edge,branch=${{github.event.repository.default_branch}},enable=${{github.event.repository.default_branch == github.ref_name}}
                       type=ref,event=pr
-                      type=sha,format=long
+                  labels: |
+                      org.opencontainers.image.title=Rollups Explorer
+                      org.opencontainers.image.description=Web app to interact with DApps
 
             - name: Login to Docker Hub
               uses: docker/login-action@v2
-              if: ${{ github.repository_owner == 'cartesi' && github.ref_type == 'tag'}}
+              if: ${{ env.push_to_dockerhub == 'true'}}
               with:
                   username: ${{ secrets.DOCKER_USERNAME }}
                   password: ${{ secrets.DOCKER_PASSWORD }}
@@ -82,6 +92,7 @@ jobs:
               with:
                   context: .
                   file: docker/Dockerfile-rollups
+                  platforms: linux/amd64,linux/arm64
                   tags: ${{ steps.docker_meta.outputs.tags }}
                   labels: ${{ steps.docker_meta.outputs.labels }}
                   builder: ${{ steps.buildx.outputs.name }}

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is a monorepo holding up two explorer applications from Cartesi. One is the
 
 This monorepo uses [Yarn v1](https://classic.yarnpkg.com/) as a package manager and is controlled by [turborepo](https://turbo.build/repo).
 
-## Package Installation
+### Package Installation
 
 You can add, remove and upgrade packages from within your monorepo using your package manager's built-in commands:
 
@@ -72,6 +72,17 @@ yarn run build
 ```
 
 > Note: We are not building the packages since it is only for internal use. **The transpilation/compilation is delegated to the application using the package.** _That may change in the future._
+
+### Release
+
+The project use **tags** that represent releases, including a branch to signal cloud providers to update the production code (e.g. Staking).
+
+That is as follows:
+
+-   Combined tag name `v` + SemVer format **tag** (e.g. v3.4.0) to pinpoint repository state on a given production release.
+-   A different **tag** format for rollups, i.e. `rollups@0.9.0`, is used to initiate the process of releasing docker images with specific versions that match the versioning other rollups projects are using for unison sake.
+
+> The process initiated for rollups docker image generation is a [GitHub Action](./.github/workflows/docker-rollups.yml)
 
 ## Turborepo Useful Links
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a monorepo holding up two explorer applications from Cartesi. One is the
 
 ## What's inside?
 
-This turborepo uses [Yarn v1](https://classic.yarnpkg.com/) as a package manager. It includes the following packages/apps:
+This monorepo uses [Yarn v1](https://classic.yarnpkg.com/) as a package manager and is controlled by [turborepo](https://turbo.build/repo).
 
 ## Package Installation
 
@@ -35,16 +35,6 @@ This turborepo has some additional tools already setup for you:
 -   [ESLint](https://eslint.org/) for code linting
 -   [Prettier](https://prettier.io) for code formatting
 
-### Build
-
-To build all apps, run the following command:
-
-```
-yarn run build
-```
-
-> Note: We are not building the packages since it is only for internal use. **The transpilation/compilation is delegated to the application using the package.** _That may change in the future._
-
 ### Develop
 
 To develop all apps and packages, run the following command:
@@ -68,9 +58,20 @@ yarn run dev --filter rollups
 ```
 
 ### Test coverage reporting
+
 We are using [Coveralls](https://coveralls.io/) as a reporting tool for our tests' coverage. Each workspace that has tests, generates coverage report for them as well using the `test:ci` npm script. At each build we merge coverage reports for all workspaces, and then send the merged report to Coveralls.
 
 To include a new workspace that has tests in the merged coverage report, all you need to do is provide in its dedicated `package.json` file the `test:ci` script (found in existing workspaces).
+
+### Build
+
+To build all apps, run the following command:
+
+```
+yarn run build
+```
+
+> Note: We are not building the packages since it is only for internal use. **The transpilation/compilation is delegated to the application using the package.** _That may change in the future._
 
 ## Turborepo Useful Links
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1270,15 +1270,6 @@
   optionalDependencies:
     fsevents "^2.3.2"
 
-"@cartesi/rollups-0.6@npm:@cartesi/rollups@0.6.0":
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/@cartesi/rollups/-/rollups-0.6.0.tgz#da00a364df02c97ea1cf0fa87c7f2c888295f68d"
-  integrity sha512-YZ7uOkweFqQGmk59BIQ/xdQOcXGCPwEOd5Mjf5ZzZlDbqGKAUBm94tRdTCclFwGWnxISe/KOZpr3AUa9KD+WWg==
-  dependencies:
-    "@cartesi/token" "^1.7.0"
-    "@cartesi/util" "^4.1.0"
-    "@openzeppelin/contracts" "^4.7.1"
-
 "@cartesi/rollups-0.8@npm:@cartesi/rollups@0.8.2":
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/@cartesi/rollups/-/rollups-0.8.2.tgz#9f8323926e9c823b331b539d6e104eb4804d5e03"
@@ -1314,7 +1305,7 @@
   dependencies:
     "@openzeppelin/contracts" "^2.5.0"
 
-"@cartesi/token@^1.2.5", "@cartesi/token@^1.3.0", "@cartesi/token@^1.7.0", "@cartesi/token@^1.7.1", "@cartesi/token@^1.8.0":
+"@cartesi/token@^1.2.5", "@cartesi/token@^1.3.0", "@cartesi/token@^1.7.1", "@cartesi/token@^1.8.0":
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/@cartesi/token/-/token-1.8.0.tgz#1f19bda1c5bd4e9e784cbd671c096e0333f11fb3"
   integrity sha512-jcr1ItbEjvhfy0A5KjOwLUd8Yqawo+F7o6p+9sxqfi1RYa39jTL1qhbF9xui4dR7slVrTwqWQTRHHwlfSHzq8A==
@@ -1333,13 +1324,6 @@
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@cartesi/util/-/util-1.0.1.tgz#7416bf9bd254b25010ce883d483666b4648b3397"
   integrity sha512-OsfgsT4OQ8ddulrkr/zsn9tnFiZdARkr0j1595UUgDAXO5QZkSpl2WjAZvOCqWg2uv5VrJjXVolvFp0jdn0iKw==
-  dependencies:
-    "@openzeppelin/contracts" "3.2.1-solc-0.7"
-
-"@cartesi/util@^4.1.0":
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/@cartesi/util/-/util-4.2.0.tgz#222dfac6870702b0204f949e2d4be33fbbd41b04"
-  integrity sha512-VgON6nI6Be3v/H1xbUmCDuOXe6Y14qCwBKKeOEUsE+GOTNbBEOpFkzmWkTGOl365h08WAhPmWP6ImlaXrKlm3w==
   dependencies:
     "@openzeppelin/contracts" "3.2.1-solc-0.7"
 


### PR DESCRIPTION
## Summary
Changes to streamline rollups docker image generation. I also include a `release` with information about the current strategy, including the new one for rollups docker image publishing. More details are below.

**What is published to`ghcr.io`:**
* For pull requests that change `rollups` or any `packages` will trigger the GA that publishes an image of your code tagged as pr-<number>
* For push events to the `main` branch changes `rollups` and/or any `packages` it will publish an image tagged as `edge`. That is a common tag that means access to fresh features, but it may be unstable. 
* Push event from a tag named e.g. `rollups@a.b.c` the image will be generated tagged as the version `a.b.c` and also tag `latest`

**What is published to `docker.io`**
* Push event from a tag named e.g. `rollups@a.b.c` the image will be generated tagged as the version `a.b.c` and also tag `latest`

**Architectures**: Currently generating for `linux/amd64` and `linux/arm64`

