### PR TITLE
#16 Optimize unit tests for packages/ui

### DIFF
--- a/packages/ui/__tests__/components/Address.test.tsx
+++ b/packages/ui/__tests__/components/Address.test.tsx
@@ -9,15 +9,14 @@
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-import React from 'react';
 import { cleanup, render, screen } from '@testing-library/react';
 import { useClipboard } from '@chakra-ui/react';
 import Address, { AddressProps } from '../../src/components/Address';
-import { ENSEntry, useENS } from '@explorer/services';
+import { ENSEntry, useENS } from '@explorer/services/src/ens';
 import { withChakraTheme } from '../test-utilities';
-import { StakePlusIcon } from '../../src/components';
+import { StakePlusIcon } from '../../src/components/Icons';
 
-jest.mock('@explorer/services', () => {
+jest.mock('@explorer/services/src/ens', () => {
     const original = jest.requireActual('@explorer/services');
     return {
         __esModule: true,

--- a/packages/ui/__tests__/components/AddressText.test.tsx
+++ b/packages/ui/__tests__/components/AddressText.test.tsx
@@ -9,17 +9,14 @@
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-import React from 'react';
 import { cleanup, render, screen } from '@testing-library/react';
 import { useClipboard } from '@chakra-ui/react';
 import { FaCoins } from 'react-icons/fa';
-import AddressText, {
-    AddressTextProps,
-} from '../../src/components/AddressText';
-import { ENSEntry, useENS } from '@explorer/services';
+import AddressText from '../../src/components/AddressText';
+import { ENSEntry, useENS } from '@explorer/services/src/ens';
 import { withChakraTheme } from '../test-utilities';
 
-jest.mock('@explorer/services', () => {
+jest.mock('@explorer/services/src/ens', () => {
     const original = jest.requireActual('@explorer/services');
     return {
         __esModule: true,
@@ -46,7 +43,7 @@ const defaultUseClipboardProps = {
     hasCopied: false,
     onCopy: () => undefined,
 };
-const Component = withChakraTheme<AddressTextProps>(AddressText);
+const Component = withChakraTheme(AddressText);
 const mockUseENS = useENS as jest.MockedFunction<typeof useENS>;
 const mockUseClipboard = useClipboard as jest.MockedFunction<
     typeof useClipboard

--- a/packages/ui/__tests__/components/Banner.test.tsx
+++ b/packages/ui/__tests__/components/Banner.test.tsx
@@ -9,15 +9,14 @@
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-import React from 'react';
 import { render, screen } from '@testing-library/react';
-import Banner, { BannerProps } from '../../src/components/Banner';
+import Banner from '../../src/components/Banner';
 import { withChakraTheme } from '../test-utilities';
 
 const defaultProps = {
     Title: <span>Title</span>,
 };
-const Component = withChakraTheme<BannerProps>(Banner);
+const Component = withChakraTheme(Banner);
 
 describe('Banner component', () => {
     const renderComponent = (props = {}) =>

--- a/packages/ui/__tests__/components/BigNumberText.test.tsx
+++ b/packages/ui/__tests__/components/BigNumberText.test.tsx
@@ -9,16 +9,15 @@
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { withChakraTheme } from '../test-utilities';
-import { BigNumberText, BigNumberTextProps } from '../../src/components';
+import BigNumberText from '../../src/components/BigNumberText';
 
 const defaultProps = {
     value: 10,
 };
 
-const Component = withChakraTheme<BigNumberTextProps>(BigNumberText);
+const Component = withChakraTheme(BigNumberText);
 
 describe('BigNumberText component', () => {
     const renderComponent = (props = {}) =>

--- a/packages/ui/__tests__/components/Card.test.tsx
+++ b/packages/ui/__tests__/components/Card.test.tsx
@@ -10,10 +10,10 @@
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
-import { Card, CardProps } from '../../src/components';
+import { Card } from '../../src/components/Card';
 import { withChakraTheme } from '../test-utilities';
 
-const ECard = withChakraTheme<CardProps>(Card);
+const ECard = withChakraTheme(Card);
 
 describe('Card component', () => {
     beforeEach(() => {

--- a/packages/ui/__tests__/components/Footer.test.tsx
+++ b/packages/ui/__tests__/components/Footer.test.tsx
@@ -10,10 +10,10 @@
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
 import { render, screen } from '@testing-library/react';
-import { Footer, FooterProps, cartesiTwitterLink } from '../../src/components';
+import Footer from '../../src/components/Footer';
 import { withChakraTheme } from '../test-utilities';
 
-const Component = withChakraTheme<FooterProps>(Footer);
+const Component = withChakraTheme(Footer);
 const defaultProps = {
     links: [
         { label: 'Google', href: 'https://google.com' },
@@ -54,7 +54,7 @@ describe('Footer component', () => {
     it('should display Cartesi twitter link', () => {
         const { container } = render(<Component {...defaultProps} />);
         const twitterLink = container.querySelector(
-            `a[href="${cartesiTwitterLink}"]`
+            `a[href="https://twitter.com/cartesiproject"]`
         );
         const isLinkInDom =
             typeof twitterLink === 'object' && twitterLink !== null;

--- a/packages/ui/__tests__/components/Layout.test.tsx
+++ b/packages/ui/__tests__/components/Layout.test.tsx
@@ -9,12 +9,11 @@
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { withChakraTheme } from '../test-utilities';
-import { Layout, LayoutProps } from '../../src/components';
+import Layout from '../../src/components/Layout';
 
-const Component = withChakraTheme<LayoutProps>(Layout);
+const Component = withChakraTheme(Layout);
 const defaultProps = {
     headerLinks: [
         {

--- a/packages/ui/__tests__/components/Notification.test.tsx
+++ b/packages/ui/__tests__/components/Notification.test.tsx
@@ -11,7 +11,7 @@
 
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { act } from 'react-dom/test-utils';
-import { Notification } from '../../src/components';
+import { Notification } from '../../src/components/Notification';
 import { withChakraTheme } from '../test-utilities';
 
 describe('Notification component', () => {

--- a/packages/ui/__tests__/components/header/ConnectWallet.test.tsx
+++ b/packages/ui/__tests__/components/header/ConnectWallet.test.tsx
@@ -9,9 +9,8 @@
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
-import { ConnectWallet, ConnectWalletProps } from '../../../src/components';
+import { ConnectWallet } from '../../../src/components/header/ConnectWallet';
 import { withChakraTheme } from '../../test-utilities';
 import { UnsupportedNetworkError } from '@explorer/wallet';
 
@@ -22,12 +21,11 @@ const defaultWallet = {
     deactivate: () => Promise.resolve(),
 };
 
-const Component = withChakraTheme<ConnectWalletProps>(ConnectWallet);
+const Component = withChakraTheme(ConnectWallet);
 
 describe('Connect Wallet', () => {
     // a default configured component
-    const renderComponent = (props: ConnectWalletProps) =>
-        render(<Component {...props} />);
+    const renderComponent = (props: any) => render(<Component {...props} />);
 
     it('Should display connect to wallet label', () => {
         renderComponent({

--- a/packages/ui/__tests__/components/header/NavBar.test.tsx
+++ b/packages/ui/__tests__/components/header/NavBar.test.tsx
@@ -9,12 +9,11 @@
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-import React from 'react';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
-import { useWallet } from '@explorer/wallet';
-import { NavBar, NavLink } from '../../../src/components';
+import { useWallet } from '@explorer/wallet/src/useWallet';
+import { NavBar, NavLink } from '../../../src/components/header/NavBar';
 
-const walletMod = `@explorer/wallet`;
+const walletMod = `@explorer/wallet/src/useWallet`;
 const account = '0x907eA0e65Ecf3af503007B382E1280Aeb46104ad';
 
 jest.mock('@unleash/proxy-client-react', () => ({

--- a/packages/ui/__tests__/components/header/modals/WalletMobileModal.test.tsx
+++ b/packages/ui/__tests__/components/header/modals/WalletMobileModal.test.tsx
@@ -9,12 +9,8 @@
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-import React from 'react';
 import { render, screen } from '@testing-library/react';
-import {
-    WalletMobileModal,
-    IWalletMobileModalProps,
-} from '../../../../src/components/header/modals/WalletMobileModal';
+import { WalletMobileModal } from '../../../../src/components/header/modals/WalletMobileModal';
 import { withChakraTheme } from '../../../test-utilities';
 
 const defaultProps = {
@@ -25,8 +21,7 @@ const defaultProps = {
     onClose: () => undefined,
 };
 
-const EWalletMobileModal =
-    withChakraTheme<IWalletMobileModalProps>(WalletMobileModal);
+const EWalletMobileModal = withChakraTheme(WalletMobileModal);
 
 describe('Staking Pool Allowance Modal', () => {
     // a default configured component

--- a/packages/ui/src/components/Footer.tsx
+++ b/packages/ui/src/components/Footer.tsx
@@ -66,8 +66,6 @@ const SocialButton = ({
     );
 };
 
-export const cartesiTwitterLink = 'https://twitter.com/cartesiproject';
-
 export type FooterLink = { label: string; href: string };
 export type FooterContract = { name: string; address?: string };
 
@@ -129,7 +127,10 @@ const Footer: FC<FooterProps> = ({ links, contracts }) => {
                         rights reserved
                     </Text>
                     <Stack direction={'row'} spacing={6}>
-                        <SocialButton label="Twitter" href={cartesiTwitterLink}>
+                        <SocialButton
+                            label="Twitter"
+                            href="https://twitter.com/cartesiproject"
+                        >
                             <FaTwitter />
                         </SocialButton>
                     </Stack>


### PR DESCRIPTION
Optimized speed of unit tests for `packages/ui` by refactoring imports.

Before the changes:
![Screenshot 2023-06-18 at 19 38 25](https://github.com/cartesi/explorer/assets/6005179/f04de878-a454-4e3f-b92e-e465691e39e5)

After the changes:
![Screenshot 2023-06-18 at 19 37 39](https://github.com/cartesi/explorer/assets/6005179/c92a12b9-a4d8-4b77-910a-a08a96204cd3)
