### PR TITLE
#17 Optimize Unit Test for apps/rollups

### DIFF
--- a/apps/rollups/__tests__/components/Web3Container.test.tsx
+++ b/apps/rollups/__tests__/components/Web3Container.test.tsx
@@ -10,14 +10,14 @@
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
 //
+import { WalletConnectionProvider } from '@explorer/wallet/src/provider';
 import { render, screen } from '@testing-library/react';
-import { WalletConnectionProvider } from '@explorer/wallet';
 import Web3Container, {
-    chainIds,
     appMetaData,
+    chainIds,
 } from '../../src/components/Web3Container';
 
-const path = '@explorer/wallet';
+const path = '@explorer/wallet/src/provider';
 jest.mock(path, () => {
     const originalModule = jest.requireActual(path);
     return {

--- a/apps/rollups/__tests__/services/useRollupsFactory.test.tsx
+++ b/apps/rollups/__tests__/services/useRollupsFactory.test.tsx
@@ -9,15 +9,17 @@
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-import { renderHook, cleanup, waitFor } from '@testing-library/react';
-import { useWallet } from '@explorer/wallet';
-import { CartesiDAppFactory__factory } from '@cartesi/rollups';
-import { useNetwork } from '../../src/services/useNetwork';
-import { useRollupsFactory } from '../../src/services/useRollupsFactory';
-import { networks } from '../../src/services/useNetwork';
-import { JsonRpcSigner } from '@ethersproject/providers/src.ts/json-rpc-provider';
+import {
+    CartesiDAppFactory,
+    CartesiDAppFactory__factory,
+} from '@cartesi/rollups';
 import { Web3Provider } from '@ethersproject/providers';
-import { CartesiDAppFactory } from '@cartesi/rollups';
+import { JsonRpcSigner } from '@ethersproject/providers/src.ts/json-rpc-provider';
+import { useWallet } from '@explorer/wallet';
+import { WalletConnectionContextProps } from '@explorer/wallet/src/definitions';
+import { cleanup, renderHook, waitFor } from '@testing-library/react';
+import { networks, useNetwork } from '../../src/services/useNetwork';
+import { useRollupsFactory } from '../../src/services/useRollupsFactory';
 
 const walletMod = '@explorer/wallet';
 const networkMod = '../../src/services/useNetwork';
@@ -112,7 +114,7 @@ describe('useRollupsFactory hook', () => {
                 getSigner: (): JsonRpcSigner =>
                     'signer' as unknown as JsonRpcSigner,
             } as Web3Provider,
-        });
+        } as unknown as WalletConnectionContextProps);
 
         await waitFor(() => {
             renderHook(() => useRollupsFactory());

--- a/apps/rollups/__tests__/services/useRollupsGraphQL.test.tsx
+++ b/apps/rollups/__tests__/services/useRollupsGraphQL.test.tsx
@@ -9,13 +9,12 @@
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-import { renderHook, cleanup } from '@testing-library/react';
-import { useWallet } from '@explorer/wallet';
-import { useNetwork } from '../../src/services/useNetwork';
+import { useWallet } from '@explorer/wallet/src/useWallet';
+import { cleanup, renderHook } from '@testing-library/react';
+import { networks, useNetwork } from '../../src/services/useNetwork';
 import { useRollupsGraphQL } from '../../src/services/useRollupsGraphQL';
-import { networks } from '../../src/services/useNetwork';
 
-const walletMod = '@explorer/wallet';
+const walletMod = `@explorer/wallet/src/useWallet`;
 const networkMod = '../../src/services/useNetwork';
 
 jest.mock(walletMod, () => {

--- a/apps/rollups/src/services/useRollupsGraphQL.tsx
+++ b/apps/rollups/src/services/useRollupsGraphQL.tsx
@@ -24,7 +24,6 @@ export const useRollupsGraphQL = (address: string, manualUrl?: string) => {
         // Guess generate URL if only address is available
         // If manual-URL is passed down (usually is a user input) that will be used instead
         const url = isEmpty(manualUrl) ? network.graphql(address) : manualUrl;
-        console.log(`${manualUrl} - ${url}`);
         return createClient({ url });
     }, [network, address, manualUrl]);
 };


### PR DESCRIPTION
## Summary

Optimizing the unit test on the `apps/rollups`

Before the changes, there are some warning on the `graphql` endpoint. Time to complete **~18s**


<img width="1103" alt="Screenshot 2023-06-23 at 14 42 00" src="https://github.com/cartesi/explorer/assets/13269955/d41ff71a-a037-4240-9b5d-627064269fca">

After the changes


<img width="1106" alt="Screenshot 2023-06-23 at 14 27 02" src="https://github.com/cartesi/explorer/assets/13269955/f8660d8b-89c7-4c3b-98f5-2e18fc4fe1f2">



## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #17 
