### PR TITLE
#18 Optimize unit tests for apps/staking

### DIFF
--- a/apps/staking/__tests__/components/ApolloContainer.test.tsx
+++ b/apps/staking/__tests__/components/ApolloContainer.test.tsx
@@ -9,8 +9,8 @@
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-import { cleanup, render, screen } from '@testing-library/react';
-import { useWallet } from '@explorer/wallet';
+import { render, screen } from '@testing-library/react';
+import { useWallet } from '@explorer/wallet/src/useWallet';
 import { useApollo } from '../../src/services/apollo';
 import ApolloContainer from '../../src/components/ApolloContainer';
 import { withChakraTheme } from '../test-utilities';
@@ -33,8 +33,8 @@ jest.mock('../../src/services/apollo', () => {
     };
 });
 
-jest.mock('@explorer/wallet', () => {
-    const originalModule = jest.requireActual('@explorer/wallet');
+jest.mock('@explorer/wallet/src/useWallet', () => {
+    const originalModule = jest.requireActual('@explorer/wallet/src/useWallet');
     return {
         __esModule: true,
         ...originalModule,
@@ -61,7 +61,6 @@ describe('ApolloContainer component', () => {
     });
 
     afterEach(() => {
-        cleanup();
         jest.clearAllMocks();
     });
 

--- a/apps/staking/__tests__/components/CTSIText.test.tsx
+++ b/apps/staking/__tests__/components/CTSIText.test.tsx
@@ -10,13 +10,11 @@
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
 import { Text } from '@chakra-ui/react';
-import { render, screen, cleanup } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { FaIcons } from 'react-icons/fa';
 import CTSIText from '../../src/components/CTSIText';
 
 describe('CTSI Text component', () => {
-    afterEach(() => cleanup());
-
     it('Should render the formatted amount of CTSI', () => {
         render(<CTSIText value="5000100000000000000000000" />);
 

--- a/apps/staking/__tests__/components/Layout.test.tsx
+++ b/apps/staking/__tests__/components/Layout.test.tsx
@@ -9,7 +9,7 @@
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-import { cleanup, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { StakingImpl, PoS } from '@cartesi/pos';
 import Layout, { headerLinks, footerLinks } from '../../src/components/Layout';
 import {
@@ -94,7 +94,6 @@ describe('Layout component', () => {
 
     afterEach(() => {
         jest.clearAllMocks();
-        cleanup();
     });
 
     it('should display correct header links', () => {

--- a/apps/staking/__tests__/components/OrderedContent.test.tsx
+++ b/apps/staking/__tests__/components/OrderedContent.test.tsx
@@ -1,11 +1,18 @@
-import { cleanup, render, screen } from '@testing-library/react';
+// Copyright (C) 2023 Cartesi Pte. Ltd.
+
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free Software
+// Foundation, either version 3 of the License, or (at your option) any later
+// version.
+
+// This program is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+// PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+import { render, screen } from '@testing-library/react';
 import { OrderedContent } from '../../src/components/OrderedContent';
 
 describe('OrderedContent component', () => {
-    afterEach(() => {
-        cleanup();
-    });
-
     it('Should render the title and list of subjected enumerated', () => {
         const title = 'Proposed activities';
         const activities = [

--- a/apps/staking/__tests__/components/PerPageSelect.test.tsx
+++ b/apps/staking/__tests__/components/PerPageSelect.test.tsx
@@ -9,7 +9,7 @@
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-import { cleanup, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import PerPageSelect from '../../src/components/PerPageSelect';
 import { withChakraTheme } from '../test-utilities';
 
@@ -22,10 +22,6 @@ const defaultProps = {
 };
 
 describe('PerPageSelect component', () => {
-    beforeEach(() => {
-        cleanup();
-    });
-
     it('should display required label', () => {
         render(<Component {...defaultProps} />);
         expect(screen.getByText('Rows per page')).toBeInTheDocument();

--- a/apps/staking/__tests__/components/Step/Step.test.tsx
+++ b/apps/staking/__tests__/components/Step/Step.test.tsx
@@ -9,8 +9,7 @@
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-import React from 'react';
-import { render, screen, cleanup } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import {
     Step,
     StepProps,
@@ -42,7 +41,6 @@ describe('Step component', () => {
     });
 
     afterEach(() => {
-        cleanup();
         jest.clearAllMocks();
     });
 

--- a/apps/staking/__tests__/components/StepGroup/StepGroup.test.tsx
+++ b/apps/staking/__tests__/components/StepGroup/StepGroup.test.tsx
@@ -8,8 +8,8 @@
 // This program is distributed in the hope that it will be useful, but WITHOUT ANY
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
-import React, { useEffect, useState } from 'react';
-import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { useEffect, useState } from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import {
     Step,
     StepActions,
@@ -74,7 +74,6 @@ describe('StepGroup component', () => {
     });
 
     afterEach(() => {
-        cleanup();
         jest.clearAllMocks();
     });
 

--- a/apps/staking/__tests__/components/SyncStatus.test.tsx
+++ b/apps/staking/__tests__/components/SyncStatus.test.tsx
@@ -9,7 +9,7 @@
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-import { render, screen, cleanup } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import SyncStatus from '../../src/components/SyncStatus';
 import { withChakraTheme } from '../test-utilities';
 import { useBlockNumber } from '../../src/services/eth';
@@ -49,7 +49,6 @@ describe('SyncStatus component', () => {
     });
 
     afterEach(() => {
-        cleanup();
         jest.clearAllMocks();
     });
 

--- a/apps/staking/__tests__/components/TimerButton.test.tsx
+++ b/apps/staking/__tests__/components/TimerButton.test.tsx
@@ -9,7 +9,6 @@
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import TimerButton, {
     TimerButtonProps,

--- a/apps/staking/__tests__/components/animation/SlideDown.test.tsx
+++ b/apps/staking/__tests__/components/animation/SlideDown.test.tsx
@@ -9,19 +9,15 @@
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-import { cleanup, render, screen } from '@testing-library/react';
-import React from 'react';
+import { render, screen } from '@testing-library/react';
 import { SlideDown } from '../../../src/components/animation/SlideDown';
 
-describe('SlideDown component', () => {
-    const DummyComponent = ({ text }) => <h1>{text}</h1>;
-    afterEach(() => {
-        cleanup();
-    });
+const DummyComponent = ({ text }) => <h1>{text}</h1>;
 
+describe('SlideDown component', () => {
     it('should be able to render children component when display prop is true', () => {
         render(
-            <SlideDown display={true}>
+            <SlideDown display>
                 <DummyComponent text="Create your own pool" />
             </SlideDown>
         );

--- a/apps/staking/__tests__/components/animation/SlideInOut.test.tsx
+++ b/apps/staking/__tests__/components/animation/SlideInOut.test.tsx
@@ -9,19 +9,15 @@
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-import { cleanup, render, screen } from '@testing-library/react';
-import React from 'react';
+import { render, screen } from '@testing-library/react';
 import { SlideInOut } from '../../../src/components/animation/SlideInOut';
 
-describe('SlideInOut component', () => {
-    const DummyComponent = ({ text }) => <h1>{text}</h1>;
-    afterEach(() => {
-        cleanup();
-    });
+const DummyComponent = ({ text }) => <h1>{text}</h1>;
 
+describe('SlideInOut component', () => {
     it('should be able to render children component when display prop is true', () => {
         render(
-            <SlideInOut display={true}>
+            <SlideInOut display>
                 <DummyComponent text="Hello there" />
             </SlideInOut>
         );

--- a/apps/staking/__tests__/components/home/PrimaryCard.test.tsx
+++ b/apps/staking/__tests__/components/home/PrimaryCard.test.tsx
@@ -10,7 +10,7 @@
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
 import { render, screen } from '@testing-library/react';
-import { ChartIcon } from '@explorer/ui';
+import { ChartIcon } from '@explorer/ui/src/components/Icons';
 import PrimaryCard from '../../../src/components/home/PrimaryCard';
 import { withChakraTheme } from '../../test-utilities';
 

--- a/apps/staking/__tests__/components/node/NodeInfoSection.test.tsx
+++ b/apps/staking/__tests__/components/node/NodeInfoSection.test.tsx
@@ -8,8 +8,7 @@
 // This program is distributed in the hope that it will be useful, but WITHOUT ANY
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
-import React from 'react';
-import { render, screen, cleanup } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { useMediaQuery } from '@chakra-ui/react';
 import { BigNumber } from 'ethers';
 import { NodeInfoSection } from '../../../src/components/node/NodeInfoSection';
@@ -66,7 +65,6 @@ describe('NodeInfoSection component', () => {
     });
 
     afterEach(() => {
-        cleanup();
         jest.clearAllMocks();
     });
 

--- a/apps/staking/__tests__/components/node/NodeMaturingSection.test.tsx
+++ b/apps/staking/__tests__/components/node/NodeMaturingSection.test.tsx
@@ -8,8 +8,7 @@
 // This program is distributed in the hope that it will be useful, but WITHOUT ANY
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
-import React from 'react';
-import { render, screen, cleanup } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { NodeMaturingSection } from '../../../src/components/node/NodeMaturingSection';
 import { BigNumber } from 'ethers';
 
@@ -18,8 +17,6 @@ const TEST_MATURING_BALANCE_CTSI = '87';
 const TEST_MATURING_TIME = '1 hour, 20 minutes';
 
 describe('NodeMaturingSection component', () => {
-    afterEach(() => cleanup());
-
     it('Should be with 0 CTSI, 6 hours', () => {
         render(<NodeMaturingSection maturingBalance={BigNumber.from(0)} />);
 

--- a/apps/staking/__tests__/components/node/NodeReleasingSection.test.tsx
+++ b/apps/staking/__tests__/components/node/NodeReleasingSection.test.tsx
@@ -8,8 +8,7 @@
 // This program is distributed in the hope that it will be useful, but WITHOUT ANY
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
-import React from 'react';
-import { render, screen, cleanup } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { NodeReleasingSection } from '../../../src/components/node/NodeReleasingSection';
 import { BigNumber } from 'ethers';
 
@@ -19,8 +18,6 @@ const TEST_RELEASING_TIME = '1 hour, 20 minutes';
 const TEST_WITHDRAW_BUTTON = `WITHDRAW (${TEST_RELEASING_TIME})`;
 
 describe('NodeReleasingSection component', () => {
-    afterEach(() => cleanup());
-
     it(`Should be 'Releasing' with ${TEST_RELEASING_BALANCE} CTSI, ${TEST_RELEASING_TIME}`, () => {
         render(
             <NodeReleasingSection

--- a/apps/staking/__tests__/components/node/NodeRetiredHistory.test.tsx
+++ b/apps/staking/__tests__/components/node/NodeRetiredHistory.test.tsx
@@ -9,8 +9,7 @@
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-import React from 'react';
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { NodeRetiredHistory } from '../../../src/components/node/NodeRetiredHistory';
 import {
     buildUseUserNodesReturn,
@@ -31,7 +30,6 @@ describe('Node Retired History', () => {
         useUserNodeStub.mockReturnValue(buildUseUserNodesReturn());
     });
     afterEach(() => {
-        cleanup();
         jest.clearAllMocks();
     });
     it('Should display the title', () => {
@@ -66,7 +64,6 @@ describe('When user has no retired node', () => {
         expect(nodeAddress).not.toBeInTheDocument();
     });
     afterEach(() => {
-        cleanup();
         jest.clearAllMocks();
     });
 });
@@ -86,7 +83,6 @@ describe('When user has retired node', () => {
         expect(tbody.length).toBe(1);
     });
     afterEach(() => {
-        cleanup();
         jest.clearAllMocks();
     });
 });

--- a/apps/staking/__tests__/components/node/NodeStakedBalanceSection.test.tsx
+++ b/apps/staking/__tests__/components/node/NodeStakedBalanceSection.test.tsx
@@ -9,7 +9,7 @@
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 import React from 'react';
-import { render, screen, cleanup } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { NodeStakedBalanceSection } from '../../../src/components/node/NodeStakedBalanceSection';
 import { BigNumber } from 'ethers';
 
@@ -17,8 +17,6 @@ const TEST_BALANCE = BigNumber.from('0x04b75e170de2fc0000');
 const TEST_BALANCE_CTSI = '87';
 
 describe('NodeStakedBalanceSection component', () => {
-    afterEach(() => cleanup());
-
     it(`Should be with ${TEST_BALANCE_CTSI} CTSI`, () => {
         render(<NodeStakedBalanceSection stakedBalance={TEST_BALANCE} />);
 

--- a/apps/staking/__tests__/components/node/inputs/InitialFundsInput.test.tsx
+++ b/apps/staking/__tests__/components/node/inputs/InitialFundsInput.test.tsx
@@ -9,19 +9,13 @@
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-import {
-    act,
-    cleanup,
-    fireEvent,
-    render,
-    screen,
-} from '@testing-library/react';
-import { useWallet } from '@explorer/wallet';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { useWallet } from '@explorer/wallet/src/useWallet';
 import { useBalance } from '../../../../src/services/eth';
 import { InitialFundsInput } from '../../../../src/components/node/inputs/InitialFundsInput';
 import { toBigNumber } from '../../../../src/utils/numberParser';
 
-const walletMod = `@explorer/wallet`;
+const walletMod = `@explorer/wallet/src/useWallet`;
 const servicesEthMod = `../../../../src/services/eth`;
 
 jest.mock(walletMod, () => {
@@ -73,7 +67,6 @@ describe('InitialFundsInput component', () => {
     });
 
     afterEach(() => {
-        cleanup();
         jest.clearAllMocks();
     });
 

--- a/apps/staking/__tests__/components/node/inputs/NodeInput.test.tsx
+++ b/apps/staking/__tests__/components/node/inputs/NodeInput.test.tsx
@@ -9,7 +9,7 @@
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { NodeInput } from '../../../../src/components/node/inputs/NodeInput';
 import { buildNodeObj } from '../mocks';
 
@@ -28,7 +28,6 @@ describe('NodeInput component', () => {
     );
 
     afterEach(() => {
-        cleanup();
         jest.clearAllMocks();
     });
 

--- a/apps/staking/__tests__/components/node/steps/CustomizeEthereumNode.test.tsx
+++ b/apps/staking/__tests__/components/node/steps/CustomizeEthereumNode.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { useBreakpointValue } from '@chakra-ui/react';
 import CustomizeEthereumNode from '../../../../src/components/node/steps/CustomizeEthereumNode';
 import { IStep } from '../../../../src/components/StepGroup';
@@ -25,7 +25,6 @@ describe('Customize Ethereum Node Step component', () => {
     });
 
     afterEach(() => {
-        cleanup();
         jest.clearAllMocks();
     });
 

--- a/apps/staking/__tests__/components/node/steps/HireNode.test.tsx
+++ b/apps/staking/__tests__/components/node/steps/HireNode.test.tsx
@@ -10,7 +10,6 @@
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
 import {
-    cleanup,
     render,
     screen,
     fireEvent,
@@ -18,7 +17,7 @@ import {
     findByText,
 } from '@testing-library/react';
 import { useBreakpointValue } from '@chakra-ui/react';
-import { useWallet } from '@explorer/wallet';
+import { useWallet } from '@explorer/wallet/src/useWallet';
 import { useBalance } from '../../../../src/services/eth';
 import { useNode } from '../../../../src/services/node';
 import HireNode from '../../../../src/components/node/steps/HireNode';
@@ -26,7 +25,7 @@ import { toBigNumber } from '../../../../src/utils/numberParser';
 import { buildNodeObj } from '../mocks';
 import { useAtom } from 'jotai';
 
-const walletMod = `@explorer/wallet`;
+const walletMod = `@explorer/wallet/src/useWallet`;
 const servicesEthMod = `../../../../src/services/eth`;
 const servicesNodeMod = `../../../../src/services/node`;
 
@@ -111,7 +110,6 @@ describe('HireNode Step', () => {
     });
 
     afterEach(() => {
-        cleanup();
         jest.clearAllMocks();
     });
 

--- a/apps/staking/__tests__/components/node/steps/SetAllowance.test.tsx
+++ b/apps/staking/__tests__/components/node/steps/SetAllowance.test.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import {
-    cleanup,
     render,
     screen,
     fireEvent,
@@ -9,7 +8,7 @@ import {
     findByText,
 } from '@testing-library/react';
 import SetAllowance from '../../../../src/components/node/steps/SetAllowance';
-import { useWallet } from '@explorer/wallet';
+import { useWallet } from '@explorer/wallet/src/useWallet';
 import { useStaking } from '../../../../src/services/staking';
 import { useCartesiToken } from '../../../../src/services/token';
 import { toBigNumber } from '../../../../src/utils/numberParser';
@@ -18,7 +17,7 @@ import { useAtom } from 'jotai';
 import { useRouter } from 'next/router';
 import { useBreakpointValue } from '@chakra-ui/react';
 
-const walletMod = `@explorer/wallet`;
+const walletMod = `@explorer/wallet/src/useWallet`;
 const servicesStakingMod = `../../../../src/services/staking`;
 const servicesTokenMod = `../../../../src/services/token`;
 
@@ -114,7 +113,6 @@ describe('SetAllowance Step', () => {
     });
 
     afterEach(() => {
-        cleanup();
         jest.clearAllMocks();
     });
 

--- a/apps/staking/__tests__/components/pools/PoolCommission.test.tsx
+++ b/apps/staking/__tests__/components/pools/PoolCommission.test.tsx
@@ -10,7 +10,6 @@
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
 import { render, screen } from '@testing-library/react';
-import humanizeDuration from 'humanize-duration';
 import PoolCommission from '../../../src/components/pools/PoolCommission';
 import { withChakraTheme } from '../../test-utilities';
 import { StakingPool } from '../../../src/graphql/models';

--- a/apps/staking/__tests__/components/pools/steps/CommissionModel.test.tsx
+++ b/apps/staking/__tests__/components/pools/steps/CommissionModel.test.tsx
@@ -10,7 +10,6 @@
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
 import {
-    cleanup,
     fireEvent,
     act,
     render,
@@ -20,7 +19,7 @@ import {
 } from '@testing-library/react';
 import CommissionModel from '../../../../src/components/pools/steps/CommissionModel';
 import { useStakingPoolFactory } from '../../../../src/services/poolFactory';
-import { useWallet } from '@explorer/wallet';
+import { useWallet } from '@explorer/wallet/src/useWallet';
 import { buildUseStakingPoolFactoryReturn } from '../mocks';
 import { buildContractReceipt } from '../../node/mocks';
 import { useAtom } from 'jotai';
@@ -29,7 +28,7 @@ import { StepStatus } from '../../../../src/components/Step';
 import { useBreakpointValue } from '@chakra-ui/react';
 
 const poolFactoryPath = '../../../../src/services/poolFactory';
-const walletMod = '@explorer/wallet';
+const walletMod = '@explorer/wallet/src/useWallet';
 const stepGroupMod = '../../../../src/components/StepGroup';
 
 jest.mock(stepGroupMod, () => {
@@ -118,7 +117,6 @@ describe('CommissionModel step component', () => {
     });
 
     afterEach(() => {
-        cleanup();
         jest.clearAllMocks();
     });
 

--- a/apps/staking/__tests__/components/pools/steps/ENS.test.tsx
+++ b/apps/staking/__tests__/components/pools/steps/ENS.test.tsx
@@ -1,14 +1,13 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import {
     act,
-    cleanup,
     findByText,
     fireEvent,
     render,
     screen,
 } from '@testing-library/react';
 
-import { useWallet } from '@explorer/wallet';
+import { useWallet } from '@explorer/wallet/src/useWallet';
 import { useAtom } from 'jotai';
 import { useRouter } from 'next/router';
 import { useStakingPool } from '../../../../src/services/pool';
@@ -19,7 +18,7 @@ import ENS from '../../../../src/components/pools/steps/ENS';
 import { StepStatus } from '../../../../src/components/Step';
 import { useBreakpointValue } from '@chakra-ui/react';
 
-const walletMod = '@explorer/wallet';
+const walletMod = '@explorer/wallet/src/useWallet';
 const stakingPoolMod = '../../../../src/services/pool';
 const stepGroupMod = '../../../../src/components/StepGroup';
 
@@ -119,7 +118,6 @@ describe('Pool ENS step', () => {
     });
 
     afterEach(() => {
-        cleanup();
         jest.clearAllMocks();
     });
 

--- a/apps/staking/__tests__/components/pools/steps/HireNode.test.tsx
+++ b/apps/staking/__tests__/components/pools/steps/HireNode.test.tsx
@@ -11,14 +11,13 @@
 
 import {
     act,
-    cleanup,
     findByText,
     fireEvent,
     render,
     screen,
     waitFor,
 } from '@testing-library/react';
-import { useWallet } from '@explorer/wallet';
+import { useWallet } from '@explorer/wallet/src/useWallet';
 import { useBalance } from '../../../../src/services/eth';
 import { useNode } from '../../../../src/services/node';
 import HireNode from '../../../../src/components/pools/steps/HireNode';
@@ -31,7 +30,7 @@ import { buildUseStakingPoolReturn, buildContractReceipt } from '../mocks';
 import { StepStatus } from '../../../../src/components/Step';
 import { useBreakpointValue } from '@chakra-ui/react';
 
-const walletMod = '@explorer/wallet';
+const walletMod = '@explorer/wallet/src/useWallet';
 const servicesEthMod = `../../../../src/services/eth`;
 const servicesNodeMod = `../../../../src/services/node`;
 const stakingPoolMod = '../../../../src/services/pool';
@@ -141,7 +140,6 @@ describe('HireNode Step', () => {
     });
 
     afterEach(() => {
-        cleanup();
         jest.clearAllMocks();
     });
 

--- a/apps/staking/__tests__/components/stake/Banner.test.tsx
+++ b/apps/staking/__tests__/components/stake/Banner.test.tsx
@@ -9,7 +9,7 @@
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-import { Banner, BannerProps } from '@explorer/ui';
+import Banner from '@explorer/ui/src/components/Banner';
 import { render, screen } from '@testing-library/react';
 import { withChakraTheme } from '../../test-utilities';
 
@@ -19,7 +19,7 @@ const defaultProps = {
     children: <span>Children</span>,
 };
 
-const Component = withChakraTheme<BannerProps>(Banner);
+const Component = withChakraTheme(Banner);
 
 describe('Banner', () => {
     const renderComponent = (props) =>

--- a/apps/staking/__tests__/components/stake/CTSINumberInput.test.tsx
+++ b/apps/staking/__tests__/components/stake/CTSINumberInput.test.tsx
@@ -9,7 +9,6 @@
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import {
     ICTSINumberInputProps,

--- a/apps/staking/__tests__/components/stake/InfoBanner.test.tsx
+++ b/apps/staking/__tests__/components/stake/InfoBanner.test.tsx
@@ -9,14 +9,7 @@
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-import React from 'react';
-import {
-    fireEvent,
-    render,
-    screen,
-    cleanup,
-    prettyDOM,
-} from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import {
     IInfoBannerProps,
     InfoBanner,
@@ -38,10 +31,6 @@ const EInfoBanner = withChakraTheme<IInfoBannerProps>(InfoBanner);
 describe('Info Banner', () => {
     // a default configured component
     const renderComponent = () => render(<EInfoBanner {...defaultProps} />);
-
-    afterEach(() => {
-        cleanup();
-    });
 
     it('Should display title', () => {
         renderComponent();

--- a/apps/staking/__tests__/components/stake/PoolActivity.test.tsx
+++ b/apps/staking/__tests__/components/stake/PoolActivity.test.tsx
@@ -9,14 +9,13 @@
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-import React from 'react';
-import { cleanup, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import {
     PoolActivity,
     IPoolActivityProps,
 } from '../../../src/components/stake/PoolActivity';
 import { withChakraTheme } from '../../test-utilities';
-import { useWallet } from '@explorer/wallet';
+import { useWallet } from '@explorer/wallet/src/useWallet';
 import usePoolActivities, {
     Activity,
 } from '../../../src/graphql/hooks/usePoolActivities';
@@ -32,7 +31,7 @@ const account = '0x907eA0e65Ecf3af503007B382E1280Aeb46104ad';
 const defaultProps = {
     poolAddress: POOL_ADDRESS,
 };
-jest.mock('@explorer/wallet');
+jest.mock('@explorer/wallet/src/useWallet');
 const mockUseWallet = useWallet as jest.MockedFunction<typeof useWallet>;
 
 const EPoolActivity = withChakraTheme<IPoolActivityProps>(PoolActivity);
@@ -69,7 +68,6 @@ describe('Pool Activity', () => {
 
     afterEach(() => {
         jest.clearAllMocks();
-        cleanup();
     });
 
     it('Should display pool filters wrapper', () => {

--- a/apps/staking/__tests__/components/stake/PoolActivityList.test.tsx
+++ b/apps/staking/__tests__/components/stake/PoolActivityList.test.tsx
@@ -9,13 +9,12 @@
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-import React from 'react';
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import {
     PoolActivityList,
     IPoolActivityListProps,
 } from '../../../src/components/stake/PoolActivityList';
-import { useWallet } from '@explorer/wallet';
+import { useWallet } from '@explorer/wallet/src/useWallet';
 import { withChakraTheme } from '../../test-utilities';
 import usePoolActivities, {
     Activity,
@@ -33,7 +32,7 @@ const defaultProps = {
     poolAddress: POOL_ADDRESS,
 };
 
-jest.mock('@explorer/wallet');
+jest.mock('@explorer/wallet/src/useWallet');
 const mockUseWallet = useWallet as jest.MockedFunction<typeof useWallet>;
 
 const EPoolActivityList =
@@ -72,7 +71,6 @@ describe('Pool Activity List', () => {
 
     afterEach(() => {
         jest.clearAllMocks();
-        cleanup();
     });
 
     it('Should display load more text', () => {

--- a/apps/staking/__tests__/components/stake/PoolBreadcrumbs.test.tsx
+++ b/apps/staking/__tests__/components/stake/PoolBreadcrumbs.test.tsx
@@ -9,8 +9,7 @@
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-import React from 'react';
-import { cleanup, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import {
     PoolBreadcrumbs,
     IPoolBreadcrumbsProps,
@@ -52,7 +51,6 @@ describe('Pool Breadcrumbs', () => {
 
     afterEach(() => {
         jest.clearAllMocks();
-        cleanup();
     });
 
     it('Should display pool link', () => {

--- a/apps/staking/__tests__/components/stake/PoolFilters.test.tsx
+++ b/apps/staking/__tests__/components/stake/PoolFilters.test.tsx
@@ -9,8 +9,7 @@
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-import React from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { PoolFilters } from '../../../src/components/stake/PoolFilters';
 import { withChakraTheme } from '../../test-utilities';
 

--- a/apps/staking/__tests__/components/stake/PoolHeader.test.tsx
+++ b/apps/staking/__tests__/components/stake/PoolHeader.test.tsx
@@ -9,10 +9,9 @@
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-import React from 'react';
-import { cleanup, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { PoolHeader } from '../../../src/components/stake/PoolHeader';
-import { useWallet } from '@explorer/wallet';
+import { useWallet } from '@explorer/wallet/src/useWallet';
 import { NextRouter, useRouter } from 'next/router';
 import { withChakraTheme } from '../../test-utilities';
 import { WalletConnectionContextProps } from '@explorer/wallet/src/definitions';
@@ -28,7 +27,7 @@ jest.mock('next/router', () => {
 });
 const mockUseRouter = useRouter as jest.MockedFunction<typeof useRouter>;
 
-jest.mock('@explorer/wallet');
+jest.mock('@explorer/wallet/src/useWallet');
 const mockUseWallet = useWallet as jest.MockedFunction<typeof useWallet>;
 
 jest.mock('@unleash/proxy-client-react', () => ({
@@ -62,7 +61,6 @@ describe('Pool Header', () => {
 
     afterEach(() => {
         jest.clearAllMocks();
-        cleanup();
     });
 
     it('Should display staking pool label', () => {

--- a/apps/staking/__tests__/components/stake/PoolPerformance.test.tsx
+++ b/apps/staking/__tests__/components/stake/PoolPerformance.test.tsx
@@ -9,7 +9,7 @@
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-import { cleanup, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { useFlag } from '@unleash/proxy-client-react';
 import PoolPerformance from '../../../src/components/stake/PoolPerformance';
 import useStakingPools from '../../../src/graphql/hooks/useStakingPools';
@@ -68,7 +68,6 @@ describe('PoolPerformance component', () => {
 
     afterEach(() => {
         jest.clearAllMocks();
-        cleanup();
     });
 
     it('Should display pagination when there is no search query', () => {

--- a/apps/staking/__tests__/components/stake/PoolSetting.test.tsx
+++ b/apps/staking/__tests__/components/stake/PoolSetting.test.tsx
@@ -9,10 +9,9 @@
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-import { useWallet } from '@explorer/wallet';
+import { useWallet } from '@explorer/wallet/src/useWallet';
 import {
     act,
-    cleanup,
     fireEvent,
     getByText,
     render,
@@ -31,8 +30,7 @@ import {
     buildUseStakingPoolFactoryReturn,
     buildUseStakingPoolReturn,
 } from '../pools/mocks';
-
-useStakingPool;
+import { StakingPool } from '../../../src/graphql/models';
 
 const pool = '0x51937974a767da96dc1c3f9a7b07742e256f0ffe';
 const account = '0x907eA0e65Ecf3af503007B382E1280Aeb46104ad';
@@ -43,7 +41,7 @@ const totalPoolBalance = '100000000000000000000000000000000';
 jest.mock('@unleash/proxy-client-react');
 const mockUseFlag = useFlag as jest.MockedFunction<typeof useFlag>;
 
-jest.mock('@explorer/wallet');
+jest.mock('@explorer/wallet/src/useWallet');
 const mockUseWallet = useWallet as jest.MockedFunction<typeof useWallet>;
 
 jest.mock('../../../src/graphql/hooks/useTotalPoolBalance');
@@ -139,12 +137,11 @@ describe('PoolSetting', () => {
             commissionPercentage: 15,
             paused: false,
             timestamp: new Date().getTime(),
-        });
+        } as StakingPool);
     });
 
     afterEach(() => {
         jest.clearAllMocks();
-        cleanup();
     });
 
     it('Should display header text', () => {

--- a/apps/staking/__tests__/components/stake/PoolTabNavigation.test.tsx
+++ b/apps/staking/__tests__/components/stake/PoolTabNavigation.test.tsx
@@ -9,8 +9,7 @@
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-import React from 'react';
-import { cleanup, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { PoolTabNavigation } from '../../../src/components/stake/PoolTabNavigation';
 import { NextRouter, useRouter } from 'next/router';
 import { withChakraTheme } from '../../test-utilities';
@@ -43,7 +42,6 @@ describe('PoolTabNavigation', () => {
 
     afterEach(() => {
         jest.clearAllMocks();
-        cleanup();
     });
 
     it('Should display pool info label', () => {

--- a/apps/staking/__tests__/components/stake/StakingActivity.test.tsx
+++ b/apps/staking/__tests__/components/stake/StakingActivity.test.tsx
@@ -9,9 +9,11 @@
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { StakingActivity } from '../../../src/components/stake/StakingActivity';
-import usePoolActivities from '../../../src/graphql/hooks/usePoolActivities';
+import usePoolActivities, {
+    Activity,
+} from '../../../src/graphql/hooks/usePoolActivities';
 
 jest.mock('../../../src/graphql/hooks/usePoolActivities');
 const mockUsePoolActivities = usePoolActivities as jest.MockedFunction<
@@ -47,14 +49,13 @@ describe('Staking Activity', () => {
                     id: '0x5316176a7262ab6cd401a212c6cd892662ea43b67537c4af22bcbc4e8cd996de',
                     timestamp: defaultTimestamp,
                     type: 'Deposit',
-                },
+                } as Activity,
             ],
         });
     });
 
     afterEach(() => {
         jest.clearAllMocks();
-        cleanup();
     });
 
     it('Should display loader and information when retrieving data', () => {

--- a/apps/staking/__tests__/components/stake/StakingDashboard.test.tsx
+++ b/apps/staking/__tests__/components/stake/StakingDashboard.test.tsx
@@ -9,7 +9,6 @@
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import {
     StakingDashboard,

--- a/apps/staking/__tests__/components/stake/StakingGuide.test.tsx
+++ b/apps/staking/__tests__/components/stake/StakingGuide.test.tsx
@@ -9,7 +9,6 @@
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import {
     StakingGuide,

--- a/apps/staking/__tests__/components/stake/StakingTabNavigation.test.tsx
+++ b/apps/staking/__tests__/components/stake/StakingTabNavigation.test.tsx
@@ -9,8 +9,7 @@
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-import React from 'react';
-import { cleanup, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { StakingTabNavigation } from '../../../src/components/stake/StakingTabNavigation';
 import { NextRouter, useRouter } from 'next/router';
 import { withChakraTheme } from '../../test-utilities';
@@ -45,7 +44,6 @@ describe('Staking Tab Navigation', () => {
 
     afterEach(() => {
         jest.clearAllMocks();
-        cleanup();
     });
 
     it('Should display pool info label', () => {

--- a/apps/staking/__tests__/components/stake/StakingWalletConnect.test.tsx
+++ b/apps/staking/__tests__/components/stake/StakingWalletConnect.test.tsx
@@ -9,7 +9,6 @@
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { StakingWalletConnect } from '../../../src/components/stake/StakingWalletConnect';
 import { withChakraTheme } from '../../test-utilities';

--- a/apps/staking/__tests__/components/stake/TransactionInfoBanner.test.tsx
+++ b/apps/staking/__tests__/components/stake/TransactionInfoBanner.test.tsx
@@ -9,7 +9,6 @@
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { TransactionInfoBanner } from '../../../src/components/stake/TransactionInfoBanner';
 import { withChakraTheme } from '../../test-utilities';

--- a/apps/staking/__tests__/components/stake/UsersChart.test.tsx
+++ b/apps/staking/__tests__/components/stake/UsersChart.test.tsx
@@ -9,7 +9,6 @@
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import UsersChart from '../../../src/components/stake/UsersChart';
 import { withChakraTheme } from '../../test-utilities';

--- a/apps/staking/__tests__/components/stake/components/AllowanceSection.test.tsx
+++ b/apps/staking/__tests__/components/stake/components/AllowanceSection.test.tsx
@@ -9,7 +9,6 @@
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { BigNumber } from 'ethers';
 import {

--- a/apps/staking/__tests__/components/stake/components/DepositSection.test.tsx
+++ b/apps/staking/__tests__/components/stake/components/DepositSection.test.tsx
@@ -9,17 +9,16 @@
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-import React from 'react';
-import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { BigNumber } from 'ethers';
 import {
     DepositSection,
     IDepositSection,
 } from '../../../../src/components/stake/components/DepositSection';
 import { withChakraTheme } from '../../../test-utilities';
-import { useWallet } from '@explorer/wallet';
+import { useWallet } from '@explorer/wallet/src/useWallet';
 
-jest.mock('@explorer/wallet');
+jest.mock('@explorer/wallet/src/useWallet');
 
 const defaultValue = '10000000000000000000000000000';
 const defaultOnDepositClick = () => undefined;
@@ -50,7 +49,6 @@ describe('Deposit Section', () => {
     });
 
     afterEach(() => {
-        cleanup();
         jest.resetAllMocks();
     });
 

--- a/apps/staking/__tests__/components/stake/components/PoolBalanceSection.test.tsx
+++ b/apps/staking/__tests__/components/stake/components/PoolBalanceSection.test.tsx
@@ -9,7 +9,6 @@
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { BigNumber } from 'ethers';
 import {

--- a/apps/staking/__tests__/components/stake/components/PoolsOverview.test.tsx
+++ b/apps/staking/__tests__/components/stake/components/PoolsOverview.test.tsx
@@ -9,7 +9,6 @@
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { act } from 'react-dom/test-utils';
 import { BigNumber } from 'ethers';

--- a/apps/staking/__tests__/components/stake/components/StakedBalanceSection.test.tsx
+++ b/apps/staking/__tests__/components/stake/components/StakedBalanceSection.test.tsx
@@ -9,7 +9,6 @@
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { BigNumber } from 'ethers';
 import {

--- a/apps/staking/__tests__/components/stake/components/StakingInstructions.test.tsx
+++ b/apps/staking/__tests__/components/stake/components/StakingInstructions.test.tsx
@@ -9,7 +9,6 @@
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { StakingInstructions } from '../../../../src/components/stake/components/StakingInstructions';
 import { withChakraTheme } from '../../../test-utilities';

--- a/apps/staking/__tests__/components/stake/components/WalletBalanceSection.test.tsx
+++ b/apps/staking/__tests__/components/stake/components/WalletBalanceSection.test.tsx
@@ -9,8 +9,7 @@
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-import React from 'react';
-import { render, screen, cleanup } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { BigNumber } from 'ethers';
 import {
     IWalletBalanceSectionProps,
@@ -18,9 +17,9 @@ import {
 } from '../../../../src/components/stake/components/WalletBalanceSection';
 import { parseCtsiValue } from '../../../../src/components/pools/staking/CTSI';
 import { withChakraTheme } from '../../../test-utilities';
-import { useWallet } from '@explorer/wallet';
+import { useWallet } from '@explorer/wallet/src/useWallet';
 
-jest.mock('@explorer/wallet');
+jest.mock('@explorer/wallet/src/useWallet');
 
 const defaultValue = '10000000000000000000000000000';
 
@@ -50,7 +49,6 @@ describe('Wallet Balance Section', () => {
     });
 
     afterEach(() => {
-        cleanup();
         jest.resetAllMocks();
     });
 

--- a/apps/staking/__tests__/components/stake/modals/StakingDepositModal.test.tsx
+++ b/apps/staking/__tests__/components/stake/modals/StakingDepositModal.test.tsx
@@ -9,7 +9,6 @@
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import {
     StakingDepositModal,

--- a/apps/staking/__tests__/components/stake/modals/StakingPoolAllowanceModal.test.tsx
+++ b/apps/staking/__tests__/components/stake/modals/StakingPoolAllowanceModal.test.tsx
@@ -9,7 +9,6 @@
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import {
     StakingPoolAllowanceModal,

--- a/apps/staking/__tests__/components/stake/modals/StakingStakeModal.test.tsx
+++ b/apps/staking/__tests__/components/stake/modals/StakingStakeModal.test.tsx
@@ -9,7 +9,6 @@
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import {
     StakingStakeModal,

--- a/apps/staking/__tests__/components/stake/modals/StakingWithdrawModal.test.tsx
+++ b/apps/staking/__tests__/components/stake/modals/StakingWithdrawModal.test.tsx
@@ -9,7 +9,6 @@
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import {
     StakingWithdrawModal,

--- a/apps/staking/__tests__/components/stake/stats/CommissionStat.test.tsx
+++ b/apps/staking/__tests__/components/stake/stats/CommissionStat.test.tsx
@@ -9,7 +9,6 @@
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import CommissionStat, {
     CommissionStatProps,

--- a/apps/staking/__tests__/components/stake/stats/EffectiveBalanceStat.test.tsx
+++ b/apps/staking/__tests__/components/stake/stats/EffectiveBalanceStat.test.tsx
@@ -9,7 +9,7 @@
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-import { act, cleanup, render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { BigNumber } from 'ethers';
 import EffectiveBalanceStat, {
@@ -39,10 +39,6 @@ describe('Effective Balance Stat', () => {
     // a default configured component
     const renderComponent = () =>
         render(<EEffectiveBalanceStat {...defaultProps} />);
-
-    afterEach(() => {
-        cleanup();
-    });
 
     it('Should display effective balance label', () => {
         renderComponent();

--- a/apps/staking/__tests__/components/stake/stats/PoolBalanceStat.test.tsx
+++ b/apps/staking/__tests__/components/stake/stats/PoolBalanceStat.test.tsx
@@ -9,7 +9,6 @@
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-import React from 'react';
 import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { BigNumber } from 'ethers';

--- a/apps/staking/__tests__/components/stake/stats/PoolPerformanceStat.test.tsx
+++ b/apps/staking/__tests__/components/stake/stats/PoolPerformanceStat.test.tsx
@@ -10,7 +10,7 @@
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
 import { QueryResult } from '@apollo/client';
-import { cleanup, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import PoolPerformanceStat, {
     PoolPerformanceStatProps,
 } from '../../../../src/components/stake/stats/PoolPerformanceStat';
@@ -61,7 +61,6 @@ describe('Pool Performance Stat', () => {
 
     afterEach(() => {
         jest.clearAllMocks();
-        cleanup();
     });
 
     it('Should display pool performance label', () => {

--- a/apps/staking/__tests__/components/stake/stats/ProductionIntervalStat.test.tsx
+++ b/apps/staking/__tests__/components/stake/stats/ProductionIntervalStat.test.tsx
@@ -9,7 +9,6 @@
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import ProductionIntervalStat, {
     ProductionIntervalStatProps,

--- a/apps/staking/__tests__/components/stake/stats/StakedBalanceStat.test.tsx
+++ b/apps/staking/__tests__/components/stake/stats/StakedBalanceStat.test.tsx
@@ -9,7 +9,6 @@
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-import React from 'react';
 import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { BigNumber } from 'ethers';

--- a/apps/staking/__tests__/components/stake/stats/UsersStat.test.tsx
+++ b/apps/staking/__tests__/components/stake/stats/UsersStat.test.tsx
@@ -9,7 +9,6 @@
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-import React from 'react';
 import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import UsersStat, {

--- a/apps/staking/__tests__/components/stake/tables/PoolCommissionsTableRow.test.tsx
+++ b/apps/staking/__tests__/components/stake/tables/PoolCommissionsTableRow.test.tsx
@@ -9,7 +9,7 @@
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-import React, { FC } from 'react';
+import { FC } from 'react';
 import { render, screen } from '@testing-library/react';
 import PoolCommissionsTableRow, {
     PoolCommissionsTableRowProps,

--- a/apps/staking/__tests__/components/stake/tables/PoolPerformanceTable.test.tsx
+++ b/apps/staking/__tests__/components/stake/tables/PoolPerformanceTable.test.tsx
@@ -10,7 +10,6 @@
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
 import {
-    cleanup,
     findByTestId,
     fireEvent,
     getByText,
@@ -57,10 +56,6 @@ describe('Pool Performance Table', () => {
 
     beforeEach(() => {
         useFlagStub.mockReturnValue(false);
-    });
-
-    afterEach(() => {
-        cleanup();
     });
 
     it('Should have required columns', () => {

--- a/apps/staking/__tests__/components/stake/tables/PoolPerformanceTableRow.test.tsx
+++ b/apps/staking/__tests__/components/stake/tables/PoolPerformanceTableRow.test.tsx
@@ -10,7 +10,7 @@
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
 import { Table, Tbody } from '@chakra-ui/react';
-import { cleanup, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { useFlag } from '@unleash/proxy-client-react';
 import { FC } from 'react';
 import PoolPerformanceTableRow, {
@@ -57,10 +57,6 @@ describe('Pool Performance Table Row', () => {
 
     beforeEach(() => {
         useFlagMock.mockReturnValue(false);
-    });
-
-    afterEach(() => {
-        cleanup();
     });
 
     it('Should have required columns', () => {

--- a/apps/staking/__tests__/components/stake/tables/UserStakingPoolsTable.test.tsx
+++ b/apps/staking/__tests__/components/stake/tables/UserStakingPoolsTable.test.tsx
@@ -9,7 +9,6 @@
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import UserStakingPoolsTable, {
     UserStakingPoolsTableProps,

--- a/apps/staking/__tests__/components/stake/tables/UserStakingPoolsTableRow.test.tsx
+++ b/apps/staking/__tests__/components/stake/tables/UserStakingPoolsTableRow.test.tsx
@@ -9,7 +9,7 @@
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-import React, { FC } from 'react';
+import { FC } from 'react';
 import { render, screen } from '@testing-library/react';
 import { Table, Tbody } from '@chakra-ui/react';
 import UserStakingPoolsTableRow, {

--- a/apps/staking/__tests__/components/stake/tables/UsersTable.test.tsx
+++ b/apps/staking/__tests__/components/stake/tables/UsersTable.test.tsx
@@ -9,7 +9,6 @@
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import UsersTable, {
     UsersTableProps,

--- a/apps/staking/__tests__/components/stake/tables/UsersTableRow.test.tsx
+++ b/apps/staking/__tests__/components/stake/tables/UsersTableRow.test.tsx
@@ -9,7 +9,7 @@
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-import React, { FC } from 'react';
+import { FC } from 'react';
 import { render, screen } from '@testing-library/react';
 import UsersTableRow, {
     UsersTableRowProps,

--- a/apps/staking/__tests__/containers/mocks.ts
+++ b/apps/staking/__tests__/containers/mocks.ts
@@ -1,7 +1,11 @@
 import { mock } from 'jest-mock-extended';
 import { useUserNodes } from '../../src/graphql/hooks/useNodes';
 import useStakingPools from '../../src/graphql/hooks/useStakingPools';
-import { NodesData, StakingPoolsData } from '../../src/graphql/models';
+import {
+    NodesData,
+    StakingPoolsData,
+    StakingPool,
+} from '../../src/graphql/models';
 import { useCartesiToken } from '../../src/services/token';
 import { toBigNumber } from '../../src/utils/numberParser';
 import { ReturnOf } from '../test-utilities';
@@ -91,7 +95,7 @@ const generateStakingPoolsData = (): { data: StakingPoolsData } => ({
                     totalBlocks: 0,
                     totalReward: '0',
                 },
-            },
+            } as StakingPool,
             {
                 amount: '0',
                 commissionPercentage: null,
@@ -120,7 +124,7 @@ const generateStakingPoolsData = (): { data: StakingPoolsData } => ({
                     totalBlocks: 0,
                     totalReward: '0',
                 },
-            },
+            } as StakingPool,
         ],
     },
 });

--- a/apps/staking/__tests__/containers/node-runners/NodeRunnerContainer.test.tsx
+++ b/apps/staking/__tests__/containers/node-runners/NodeRunnerContainer.test.tsx
@@ -10,10 +10,9 @@
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-import { UseWallet } from '@explorer/wallet';
+import { UseWallet } from '@explorer/wallet/src/useWallet';
 import {
     act,
-    cleanup,
     findByText,
     fireEvent,
     getByRole,
@@ -119,7 +118,6 @@ describe('NodeRunners container (Landing Page)', () => {
     });
 
     afterEach(() => {
-        cleanup();
         jest.clearAllMocks();
         localStorage.clear();
     });

--- a/apps/staking/__tests__/contexts/ga4Tracker.test.tsx
+++ b/apps/staking/__tests__/contexts/ga4Tracker.test.tsx
@@ -9,16 +9,9 @@
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-import {
-    cleanup,
-    render,
-    screen,
-    fireEvent,
-    waitFor,
-    act,
-} from '@testing-library/react';
+import { render, waitFor, act } from '@testing-library/react';
 import ReactGA from 'react-ga4';
-import { useWallet } from '@explorer/wallet';
+import { useWallet } from '@explorer/wallet/src/useWallet';
 import {
     measurementID,
     anonymizeUser,
@@ -27,7 +20,7 @@ import {
 } from '../../src/contexts/ga4Tracker';
 import { Network } from '../../src/utils/networks';
 
-const walletMod = '@explorer/wallet';
+const walletMod = '@explorer/wallet/src/useWallet';
 jest.mock(walletMod, () => {
     const originalModule = jest.requireActual(walletMod);
     return {

--- a/apps/staking/__tests__/contexts/wallet/helpers.tsx
+++ b/apps/staking/__tests__/contexts/wallet/helpers.tsx
@@ -1,5 +1,5 @@
 import { isFunction } from 'lodash/fp';
-import { useWallet } from '@explorer/wallet';
+import { useWallet } from '@explorer/wallet/src/useWallet';
 
 /**
  * Helper test component to support testing the provider.

--- a/apps/staking/__tests__/contexts/wallet/useOnboard.test.tsx
+++ b/apps/staking/__tests__/contexts/wallet/useOnboard.test.tsx
@@ -9,15 +9,16 @@
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-import { cleanup, render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { useUnleashContext } from '@unleash/proxy-client-react';
-import { WalletConnectionProvider, useWallet } from '@explorer/wallet';
+import { useWallet } from '@explorer/wallet/src/useWallet';
+import { WalletConnectionProvider } from '@explorer/wallet/src/provider';
 import { TestComponent } from './helpers';
 import { useOnboard } from '@explorer/wallet/src/useOnboard';
 import { buildMockUseOnboardV2Return } from './mocks';
 import { Network, networks } from '../../../src/utils/networks';
 
-const walletMod = '@explorer/wallet';
+const walletMod = '@explorer/wallet/src/useWallet';
 
 jest.mock(walletMod, () => {
     const originalModule = jest.requireActual(walletMod);
@@ -75,7 +76,6 @@ describe('Wallet Provider', () => {
     });
 
     afterEach(() => {
-        cleanup();
         jest.resetAllMocks();
         jest.restoreAllMocks();
     });

--- a/apps/staking/__tests__/services/ens.test.ts
+++ b/apps/staking/__tests__/services/ens.test.ts
@@ -9,16 +9,16 @@
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-import { cleanup, renderHook, waitFor } from '@testing-library/react';
+import { renderHook, waitFor } from '@testing-library/react';
 import { ethers } from 'ethers';
-import { useWallet } from '@explorer/wallet';
+import { useWallet } from '@explorer/wallet/src/useWallet';
 import { useENS } from '../../src/services/ens';
 import { Web3Provider } from '@ethersproject/providers';
 import { WalletConnectionContextProps } from '@explorer/wallet/src/definitions';
 
 jest.mock('ethers');
 
-jest.mock('@explorer/wallet');
+jest.mock('@explorer/wallet/src/useWallet');
 
 const address = '0x51937974a767da96dc1c3f9a7b07742e256f0ffe';
 const mockedGetAddress = ethers.utils.getAddress as jest.MockedFunction<
@@ -50,7 +50,6 @@ describe('ens service', () => {
     });
 
     afterEach(() => {
-        cleanup();
         jest.clearAllMocks();
     });
 

--- a/apps/staking/__tests__/services/eth.test.ts
+++ b/apps/staking/__tests__/services/eth.test.ts
@@ -9,15 +9,15 @@
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-import { cleanup, renderHook, waitFor } from '@testing-library/react';
-import { useWallet } from '@explorer/wallet';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useWallet } from '@explorer/wallet/src/useWallet';
 import { isAddress } from '@ethersproject/address';
 import { useBalance, useBlockNumber } from '../../src/services/eth';
 import { Web3Provider } from '@ethersproject/providers';
 import { WalletConnectionContextProps } from '@explorer/wallet/src/definitions';
 import { BigNumber } from 'ethers';
 
-jest.mock('@explorer/wallet');
+jest.mock('@explorer/wallet/src/useWallet');
 jest.mock('@ethersproject/address', () => {
     const originalModule = jest.requireActual('@ethersproject/address');
     return {
@@ -55,7 +55,6 @@ describe('eth service', () => {
     });
 
     afterEach(() => {
-        cleanup();
         jest.clearAllMocks();
     });
 

--- a/apps/staking/__tests__/services/node.test.ts
+++ b/apps/staking/__tests__/services/node.test.ts
@@ -9,10 +9,10 @@
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-import { cleanup, renderHook, waitFor } from '@testing-library/react';
-import { useWallet } from '@explorer/wallet';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useWallet } from '@explorer/wallet/src/useWallet';
 import { isAddress } from '@ethersproject/address';
-import { useBalance, useBlockNumber } from '../../src/services/eth';
+import { useBalance } from '../../src/services/eth';
 import { Web3Provider } from '@ethersproject/providers';
 import { useWorkerManagerContract } from '../../src/services/contracts';
 import { WalletConnectionContextProps } from '@explorer/wallet/src/definitions';
@@ -25,7 +25,7 @@ import { useNode } from '../../src/services/node';
 import { act } from 'react-dom/test-utils';
 import { BigNumber } from 'ethers';
 
-jest.mock('@explorer/wallet');
+jest.mock('@explorer/wallet/src/useWallet');
 jest.mock('@ethersproject/address', () => {
     const originalModule = jest.requireActual('@ethersproject/address');
     return {
@@ -136,7 +136,6 @@ describe('node service', () => {
     });
 
     afterEach(() => {
-        cleanup();
         jest.clearAllMocks();
     });
 

--- a/apps/staking/__tests__/services/pool.test.ts
+++ b/apps/staking/__tests__/services/pool.test.ts
@@ -32,7 +32,7 @@ import {
 import { act } from 'react-dom/test-utils';
 import { BigNumber, FixedNumber } from 'ethers';
 
-jest.mock('@explorer/wallet');
+jest.mock('@explorer/wallet/src/useWallet');
 
 jest.mock('../../src/services/transaction', () => ({
     useTransaction: jest.fn(),

--- a/apps/staking/__tests__/services/poolFactory.test.ts
+++ b/apps/staking/__tests__/services/poolFactory.test.ts
@@ -10,7 +10,7 @@
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
 import { cleanup, renderHook, waitFor } from '@testing-library/react';
-import { useWallet } from '@explorer/wallet';
+import { useWallet } from '@explorer/wallet/src/useWallet';
 import { useStakingPoolFactory } from '../../src/services/poolFactory';
 import { useTransaction, Transaction } from '../../src/services/transaction';
 import { Web3Provider } from '@ethersproject/providers';
@@ -19,7 +19,7 @@ import { useStakingPoolFactoryContract } from '../../src/services/contracts';
 import { StakingPoolFactoryImpl } from '@cartesi/staking-pool';
 import { act } from 'react-dom/test-utils';
 
-jest.mock('@explorer/wallet');
+jest.mock('@explorer/wallet/src/useWallet');
 
 jest.mock('../../src/services/transaction', () => ({
     useTransaction: jest.fn(),

--- a/apps/staking/__tests__/services/staking.test.ts
+++ b/apps/staking/__tests__/services/staking.test.ts
@@ -9,7 +9,7 @@
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-import { cleanup, renderHook, waitFor } from '@testing-library/react';
+import { renderHook, waitFor } from '@testing-library/react';
 import { act } from 'react-dom/test-utils';
 import { useStaking } from '../../src/services/staking';
 import { useStakingContract } from '../../src/services/contracts';
@@ -62,7 +62,6 @@ describe('staking service', () => {
     });
 
     afterEach(() => {
-        cleanup();
         jest.clearAllMocks();
     });
 

--- a/apps/staking/__tests__/services/token.test.ts
+++ b/apps/staking/__tests__/services/token.test.ts
@@ -9,7 +9,7 @@
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-import { cleanup, renderHook, waitFor } from '@testing-library/react';
+import { renderHook, waitFor } from '@testing-library/react';
 import { act } from 'react-dom/test-utils';
 import { useCartesiTokenContract } from '../../src/services/contracts';
 import { useTransaction, Transaction } from '../../src/services/transaction';
@@ -52,7 +52,6 @@ describe('token service', () => {
     });
 
     afterEach(() => {
-        cleanup();
         jest.clearAllMocks();
     });
 

--- a/apps/staking/__tests__/services/transaction.test.ts
+++ b/apps/staking/__tests__/services/transaction.test.ts
@@ -1,6 +1,17 @@
-import { renderHook, act, cleanup, waitFor } from '@testing-library/react';
+// Copyright (C) 2023 Cartesi Pte. Ltd.
+
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free Software
+// Foundation, either version 3 of the License, or (at your option) any later
+// version.
+
+// This program is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+// PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+import { renderHook, act, waitFor } from '@testing-library/react';
 import { ContractTransaction } from 'ethers';
-import { useWallet } from '@explorer/wallet';
+import { useWallet } from '@explorer/wallet/src/useWallet';
 import { Transaction, useTransaction } from '../../src/services/transaction';
 import { confirmations, Network } from '../../src/utils/networks';
 import {
@@ -9,7 +20,7 @@ import {
     buildContractReceiptEvent,
 } from './mocks';
 
-const walletMod = '@explorer/wallet';
+const walletMod = '@explorer/wallet/src/useWallet';
 
 jest.mock(walletMod, () => {
     const originalModule = jest.requireActual(walletMod);
@@ -36,7 +47,6 @@ describe('Transaction service', () => {
     });
 
     afterEach(() => {
-        cleanup();
         jest.clearAllMocks();
     });
 


### PR DESCRIPTION
Optimized speed of unit tests for `apps/staking` by refactoring imports.

Before the changes:
![Screenshot 2023-06-29 at 15 06 49](https://github.com/cartesi/explorer/assets/6005179/26b26cc1-43dc-4471-8842-504023853107)

After the changes:
![Screenshot 2023-06-29 at 16 37 43](https://github.com/cartesi/explorer/assets/6005179/96984b58-f45e-4aa8-b95a-2dba68bbd637)

