### PR TITLE
Replacing QEMU with Depot

### DIFF
--- a/.github/workflows/docker-rollups.yml
+++ b/.github/workflows/docker-rollups.yml
@@ -4,11 +4,11 @@ on:
         paths:
             - 'apps/rollups/**'
             - 'packages/**'
+            - '.github/workflows/docker-rollups.yml'
     push:
         paths:
             - 'apps/rollups/**'
             - 'packages/**'
-            - './github/workflows/docker-rollups.yml'
         branches:
             - main
         tags:
@@ -26,6 +26,8 @@ concurrency:
 env:
     image_name: rollups-explorer
     push_to_dockerhub: ${{startsWith(github.ref, 'refs/tags/rollups@')}}
+    override_bake: |
+        default.dockerfile=./docker/Dockerfile-rollups
 
 jobs:
     build:
@@ -51,9 +53,6 @@ jobs:
 
             - name: Run Tests
               run: yarn test
-
-            - name: Set Up QEMU
-              uses: docker/setup-qemu-action@v2
 
             - name: Set Up Docker Buildx
               id: buildx
@@ -88,14 +87,16 @@ jobs:
                   username: ${{ github.actor }}
                   password: ${{ secrets.GITHUB_TOKEN }}
 
-            - name: Build & Push Docker Image
-              id: docker_build
-              uses: docker/build-push-action@v4
+            - name: Setup Depot CLI
+              uses: depot/setup-action@v1
+
+            - name: Build & Push Docker Image (Depot)
+              uses: depot/bake-action@v1
               with:
-                  context: .
-                  file: docker/Dockerfile-rollups
-                  platforms: linux/amd64,linux/arm64
-                  tags: ${{ steps.docker_meta.outputs.tags }}
-                  labels: ${{ steps.docker_meta.outputs.labels }}
-                  builder: ${{ steps.buildx.outputs.name }}
+                  project: ${{ vars.DEPOT_PROJECT }}
+                  workdir: .
+                  set: ${{ env.override_bake }}
+                  files: |
+                      docker/docker-bake.rollups.hcl
+                      ${{ steps.docker_meta.outputs.bake-file }}
                   push: true

--- a/.github/workflows/docker-rollups.yml
+++ b/.github/workflows/docker-rollups.yml
@@ -8,14 +8,16 @@ on:
         paths:
             - 'apps/rollups/**'
             - 'packages/**'
+            - './github/workflows/docker-rollups.yml'
         branches:
-            - main 
+            - main
         tags:
             - rollups@*
 
 permissions:
-    packages: write
     contents: read
+    packages: write
+    id-token: write
 
 concurrency:
     group: ${{github.workflow}}-${{github.ref_name}}

--- a/docker/docker-bake.rollups.hcl
+++ b/docker/docker-bake.rollups.hcl
@@ -1,0 +1,8 @@
+target "docker-metadata-action" {}
+
+target default {
+    inherits = ["docker-metadata-action"]
+    dockerfile = "Dockerfile-rollups"
+    platforms = ["linux/amd64", "linux/arm64"]
+}
+


### PR DESCRIPTION
Changes applied to the GitHub action that generates docker images for the Rollup Explorer app. 

1. Added integration with Depot. 
2. Add permission for issuing OIDC tokens for the workflow run.
3. Removed QEMU setup step
4. Removed docker/build-push-action step 
5. **Added a docker-bake.hcl to describe a high-level build command.**
6. Also, added a bake-override in the workflow definition to avoid problems with working directory. 