### PR TITLE
Fix: App navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.5.2] - 2023-07-18
+
+-   `Staking`
+    -   Fix applied to bring the app navigation to its normal flow.
+
 ## [3.5.1] - 2023-07-12
 
 -   `Staking`
@@ -327,8 +332,9 @@ Staking Pools
 
 -   First release
 
-[unreleased]: https://github.com/cartesi/explorer/compare/v3.5.1...HEAD
-[3.5.0]: https://github.com/cartesi/explorer/compare/v3.5.0...v3.5.1
+[unreleased]: https://github.com/cartesi/explorer/compare/v3.5.2...HEAD
+[3.5.2]: https://github.com/cartesi/explorer/compare/v3.5.1...v3.5.2
+[3.5.1]: https://github.com/cartesi/explorer/compare/v3.5.0...v3.5.1
 [3.5.0]: https://github.com/cartesi/explorer/compare/v3.4.0...v3.5.0
 [3.4.0]: https://github.com/cartesi/explorer/compare/v3.3.0...v3.4.0
 [3.3.0]: https://github.com/cartesi/explorer/compare/v3.2.2...v3.3.0

--- a/apps/staking/__tests__/contexts/ga4Tracker.test.tsx
+++ b/apps/staking/__tests__/contexts/ga4Tracker.test.tsx
@@ -9,14 +9,14 @@
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-import { render, waitFor, act } from '@testing-library/react';
-import ReactGA from 'react-ga4';
 import { useWallet } from '@explorer/wallet/src/useWallet';
+import { act, render, waitFor } from '@testing-library/react';
+import ReactGA from 'react-ga4';
 import {
-    measurementID,
-    anonymizeUser,
-    GA4TrackerProvider,
     CustomDimensions,
+    GA4TrackerProvider,
+    anonymizeUser,
+    measurementID,
 } from '../../src/contexts/ga4Tracker';
 import { Network } from '../../src/utils/networks';
 
@@ -41,11 +41,14 @@ const mockedSet = ReactGA.set as jest.MockedFunction<typeof ReactGA.set>;
 const mockUseWallet = useWallet as jest.MockedFunction<typeof useWallet>;
 
 const account = '0x907eA0e65Ecf3af503007B382E1280Aeb46104ad';
+const activate = jest.fn();
+const deactivate = jest.fn();
+
 const walletMock = {
     account,
     active: true,
-    activate: jest.fn(),
-    deactivate: jest.fn(),
+    activate,
+    deactivate,
     chainId: Network.MAINNET,
     walletName: 'Wallet ABC',
 };
@@ -103,11 +106,16 @@ describe('ga4Tracker context', () => {
         };
         const mockedImplementation = jest.fn();
         mockedEvent.mockImplementation(mockedImplementation);
+
+        //Wallet is not connected
+        mockUseWallet.mockReturnValue({ active: false, activate, deactivate });
         const { rerender } = render(
             <GA4TrackerProvider>Content</GA4TrackerProvider>
         );
 
         await act(() => {
+            // Return wallet information and rerender
+            mockUseWallet.mockReturnValue(walletMock);
             rerender(<GA4TrackerProvider>Content</GA4TrackerProvider>);
         });
 
@@ -127,11 +135,15 @@ describe('ga4Tracker context', () => {
         };
         const mockedImplementation = jest.fn();
         mockedSet.mockImplementation(mockedImplementation);
+        //Wallet is not connected
+        mockUseWallet.mockReturnValue({ active: false, activate, deactivate });
         const { rerender } = render(
             <GA4TrackerProvider>Content</GA4TrackerProvider>
         );
 
         await act(() => {
+            // Return wallet information and rerender
+            mockUseWallet.mockReturnValue(walletMock);
             rerender(<GA4TrackerProvider>Content</GA4TrackerProvider>);
         });
 

--- a/apps/staking/src/contexts/ga4Tracker.tsx
+++ b/apps/staking/src/contexts/ga4Tracker.tsx
@@ -9,9 +9,9 @@
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-import { createContext, ReactNode, useState, useEffect } from 'react';
-import ReactGA from 'react-ga4';
 import { useWallet } from '@explorer/wallet';
+import { ReactNode, createContext, useEffect, useState } from 'react';
+import ReactGA from 'react-ga4';
 
 export const measurementID = 'G-0J9KC579GV';
 
@@ -60,7 +60,7 @@ const GA4TrackerProvider = (props: TrackingProviderProps) => {
                 hasUser: !!account,
             }));
         }
-    }, [account, analytics]);
+    }, [account]);
 
     useEffect(() => {
         const { isInitialised } = analytics;
@@ -70,7 +70,7 @@ const GA4TrackerProvider = (props: TrackingProviderProps) => {
             };
             ReactGA.event('Wallet Selection', params);
         }
-    }, [analytics, walletName]);
+    }, [walletName]);
 
     // is returning nothing as context-value at the moment
     return (


### PR DESCRIPTION
## Summary
A report was made that links in the headers were changing the address bar, but the app would not "display" the page itself. But the reality is that the links and buttons (usually calling the next router programmatically) would also not work. After checking the released tags, the problem was introduced on [v3.5.0](https://github.com/cartesi/explorer/releases/tag/v3.5.0) after checking the [changes between the tags](https://github.com/cartesi/explorer/compare/v3.4.0...v3.5.0?diff=unified), the cause was an item added in the `useEffect` watchlist causing an infinite loop in two `useEffect` hooks inside the ga4Tracker.tsx [here](https://github.com/cartesi/explorer/blob/32f43b7f0ad80283d2b8fbd4777571959ba2cb4e/apps/staking/src/contexts/ga4Tracker.tsx#L63) and [here](https://github.com/cartesi/explorer/blob/32f43b7f0ad80283d2b8fbd4777571959ba2cb4e/apps/staking/src/contexts/ga4Tracker.tsx#L73). The gist is that the main-thread was flooded with calls and nextJS router system was having a hard time to do its job. 

## Before and After
![before-changes](https://github.com/cartesi/explorer/assets/1239768/3d7a06d6-379e-4ae6-93a1-7f0527393a6f)


![after-changes](https://github.com/cartesi/explorer/assets/1239768/acdfe143-abe0-4135-aa6b-8831f0ef0a22)


