### PR TITLE
#49 Add no inputs label

### DIFF
--- a/apps/rollups/src/containers/rollups/DApp.tsx
+++ b/apps/rollups/src/containers/rollups/DApp.tsx
@@ -430,10 +430,24 @@ export const DApp: FC<DAppProps> = (props) => {
                     </InputGroup>
                 </HStack>
                 <SimpleGrid columns={1} spacing="5" py={4}>
-                    {inputEdge.data &&
-                        inputEdge.data.inputs.edges.map((edge) => (
-                            <InputEdgeItem node={edge.node} key={edge.cursor} />
-                        ))}
+                    {inputEdge.data && (
+                        <>
+                            {inputEdge.data.inputs.edges.length > 0 ? (
+                                <>
+                                    {inputEdge.data.inputs.edges.map((edge) => (
+                                        <InputEdgeItem
+                                            node={edge.node}
+                                            key={edge.cursor}
+                                        />
+                                    ))}
+                                </>
+                            ) : (
+                                <Text textAlign="center">
+                                    Looks like there are no inputs yet...
+                                </Text>
+                            )}
+                        </>
+                    )}
                 </SimpleGrid>
             </Box>
         </>


### PR DESCRIPTION
Added no inputs label. 

Before:
![Screenshot 2023-07-24 at 14 45 32](https://github.com/cartesi/explorer/assets/6005179/5239ab45-5352-42f2-87fc-0c3943c0a056)

After:
![Screenshot 2023-07-24 at 14 45 38](https://github.com/cartesi/explorer/assets/6005179/e91fce56-0d98-41e8-b059-a9d62181ad40)
