### PR TITLE
#60 Update blocks page UI

### DIFF
--- a/apps/staking/src/components/BlocksChart.tsx
+++ b/apps/staking/src/components/BlocksChart.tsx
@@ -24,7 +24,7 @@ import {
 } from 'recharts';
 import { QueryResult } from '@apollo/client';
 import { BlocksData, BlocksVars } from '../graphql/models';
-import { useColorModeValue } from '@chakra-ui/react';
+import { useColorMode, useColorModeValue } from '@chakra-ui/react';
 
 export interface BlocksChartProps {
     result: QueryResult<BlocksData, BlocksVars>;
@@ -45,6 +45,8 @@ const colors = [
 
 const BlocksChart = (props: BlocksChartProps) => {
     const blocks = props.result.data?.blocks || [];
+    const { colorMode } = useColorMode();
+    const defaultColor = colorMode === 'light' ? '#5dd54b' : '#00f6ff';
 
     // group blocks per chain
     const blocksPerChain = _.groupBy(
@@ -88,7 +90,7 @@ const BlocksChart = (props: BlocksChartProps) => {
 
         // follow tinygraphs color pattern
         const id = chain.number;
-        const color = id >= 0 && id < colors.length ? colors[id] : colors[0];
+        const color = id > 0 && id < colors.length ? colors[id] : defaultColor;
 
         // create scatter plot
         return (
@@ -122,7 +124,7 @@ const BlocksChart = (props: BlocksChartProps) => {
         return value;
     };
 
-    const bg = useColorModeValue('white', '#2D3748'); // gray.700 = #2D3748
+    const bg = useColorModeValue('white', '#161618'); // dark.gray.primary = #161618
     return (
         <ResponsiveContainer height={300}>
             <ScatterChart>

--- a/apps/staking/src/components/PageHeader.tsx
+++ b/apps/staking/src/components/PageHeader.tsx
@@ -10,7 +10,12 @@
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
 import React, { FunctionComponent } from 'react';
-import { Heading, HStack, StackProps } from '@chakra-ui/react';
+import {
+    Heading,
+    HStack,
+    StackProps,
+    useColorModeValue,
+} from '@chakra-ui/react';
 
 export interface PageHeaderProps extends StackProps {
     title: string;
@@ -18,13 +23,15 @@ export interface PageHeaderProps extends StackProps {
 
 const PageHeader: FunctionComponent<PageHeaderProps> = (props) => {
     const { title, children, ...rest } = props;
+    const bg = useColorModeValue('gray.900', 'dark.gray.tertiary');
+
     return (
         <HStack
             w="100%"
             px="6vw"
             py="5"
             color="white"
-            bg="gray.900"
+            bg={bg}
             justify="space-between"
             {...rest}
         >

--- a/apps/staking/src/components/SearchInput.tsx
+++ b/apps/staking/src/components/SearchInput.tsx
@@ -31,11 +31,12 @@ const SearchInput: FunctionComponent<SearchInputProps> = (props) => {
         'gray.50',
         'dark.gray.tertiary'
     );
+    const iconColor = useColorModeValue('gray.900', 'white');
 
     return (
         <InputGroup {...rest}>
             <InputLeftElement pointerEvents="none">
-                <SearchIcon />
+                <SearchIcon color={iconColor} />
             </InputLeftElement>
 
             <Input

--- a/apps/staking/src/components/block/BlockCard.tsx
+++ b/apps/staking/src/components/block/BlockCard.tsx
@@ -30,15 +30,19 @@ export interface BlockCardProps extends StackProps {
 
 const BlockCard: FC<BlockCardProps> = (props) => {
     const { chainId, block, highlight, highlightColor, ...stackProps } = props;
-    const bg = useColorModeValue('white', 'gray.700');
+    const bg = useColorModeValue('white', 'dark.gray.tertiary');
+    const borderColor = useColorModeValue('gray.900', 'dark.gray.quaternary');
+    const boxShadow = useColorModeValue('md', 'none');
+
     return (
         <HStack
-            shadow="md"
+            shadow={boxShadow}
             p={4}
             bg={bg}
-            borderLeftWidth={10}
-            borderLeftColor="gray.900"
+            borderLeftWidth={16}
+            borderLeftColor={borderColor}
             align="flex-start"
+            borderRadius="1rem"
             {...stackProps}
         >
             <Box w="100%">

--- a/apps/staking/src/pages/blocks/[[...block]].tsx
+++ b/apps/staking/src/pages/blocks/[[...block]].tsx
@@ -63,7 +63,10 @@ const BlockList = (props: BlockListProps) => {
     const { chainId, result, filterField, filterValue, ...stackProps } = props;
     const { data, loading, fetchMore } = result;
     const blocks = data?.blocks || [];
-    const highlightColor = useColorModeValue('lightyellow', 'header');
+    const highlightColor = useColorModeValue(
+        'lightyellow',
+        'dark.gray.quaternary'
+    );
 
     // handler for the "load more" button
     const loadMore = () => {
@@ -129,6 +132,7 @@ const Blocks: FC<BlocksProps> = ({ chainId }) => {
 
     // list of blocks filtered by node
     const byNode = useBlocks({ node: searchKey }, 20);
+    const pageBg = useColorModeValue('white', 'dark.gray.primary');
 
     return (
         <Layout>
@@ -141,7 +145,7 @@ const Blocks: FC<BlocksProps> = ({ chainId }) => {
                 />
             </PageHeader>
 
-            <HStack w="100%" px="6vw" py="5">
+            <HStack w="100%" px="6vw" py="5" bg={pageBg}>
                 <BlocksChart result={all} />
             </HStack>
 
@@ -152,6 +156,7 @@ const Blocks: FC<BlocksProps> = ({ chainId }) => {
                     w="100%"
                     px="6vw"
                     py="5"
+                    bg={pageBg}
                 />
             )}
             <BlockList
@@ -162,6 +167,7 @@ const Blocks: FC<BlocksProps> = ({ chainId }) => {
                 w="100%"
                 px="6vw"
                 py="5"
+                bg={pageBg}
             />
             <BlockList
                 chainId={chainId}
@@ -171,6 +177,7 @@ const Blocks: FC<BlocksProps> = ({ chainId }) => {
                 w="100%"
                 px="6vw"
                 py="5"
+                bg={pageBg}
             />
         </Layout>
     );

--- a/packages/ui/src/styles/foundations/colors.ts
+++ b/packages/ui/src/styles/foundations/colors.ts
@@ -104,7 +104,7 @@ export const colors = {
         secondary: '#008DA5',
         gray: {
             primary: '#161618',
-            secondary: '#1c1b1f',
+            secondary: '#1C1B1F',
             tertiary: '#232226',
             quaternary: '#39383C',
             quinary: 'rgba(241, 242, 245, 0.5)',


### PR DESCRIPTION
Uses as base branch `feature/57-update-stake-page-ui` ([PR](https://github.com/cartesi/explorer/pull/80)).

This is how the blocks page looks after the changes:
https://github.com/cartesi/explorer/assets/6005179/56ba783d-5629-4402-9006-b0e1727d431e



