### PR TITLE
chore:  Update footer links to navigate to functional content.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.7.1] - 2024-01-10
+
+-   Footer links were updated.
+
 ## [3.7.0] - 2023-09-20
 
 -   The Staking application got a new look and feel. Following the new brand colors.
@@ -356,7 +360,8 @@ Staking Pools
 
 -   First release
 
-[unreleased]: https://github.com/cartesi/explorer/compare/v3.7.0...HEAD
+[unreleased]: https://github.com/cartesi/explorer/compare/v3.7.1...HEAD
+[3.7.1]: https://github.com/cartesi/explorer/compare/v3.7.1...v3.7.0
 [3.7.0]: https://github.com/cartesi/explorer/compare/v3.7.0...v3.6.2
 [3.6.2]: https://github.com/cartesi/explorer/compare/v3.6.1...v3.6.2
 [3.6.1]: https://github.com/cartesi/explorer/compare/v3.6.0...v3.6.1

--- a/apps/staking/src/components/Layout.tsx
+++ b/apps/staking/src/components/Layout.tsx
@@ -9,6 +9,7 @@
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
+import { FlexProps } from '@chakra-ui/react';
 import { Layout, PageBody, PageHeader, PagePanel } from '@explorer/ui';
 import React, { FC } from 'react';
 import {
@@ -20,7 +21,6 @@ import {
     useWorkerManagerContract,
 } from '../services/contracts';
 import SyncStatus from './SyncStatus';
-import { FlexProps } from '@chakra-ui/react';
 
 export { PageBody, PageHeader, PagePanel };
 
@@ -53,8 +53,8 @@ export const headerLinks = [
 
 export const footerLinks = [
     {
-        label: 'CTSI Reserve Mining',
-        href: 'https://cartesi.io/en/mine/',
+        label: 'Governance & Grants',
+        href: 'https://cartesi.io/governance/',
     },
     {
         label: 'Audit Report',
@@ -62,7 +62,7 @@ export const footerLinks = [
     },
     {
         label: 'How to Run a Node',
-        href: 'https://medium.com/cartesi/running-a-node-and-staking-42523863970e',
+        href: 'https://docs.cartesi.io/earn-ctsi/run-node/',
     },
 ];
 
@@ -77,10 +77,10 @@ export const footerSupport = [
     },
     {
         label: 'FAQ',
-        href: 'https://github.com/cartesi/noether/wiki/FAQ',
+        href: 'https://docs.cartesi.io/earn-ctsi/staking-faq/',
     },
     {
-        label: 'Governance',
+        label: 'Governance Forum',
         href: 'https://governance.cartesi.io/',
     },
 ];


### PR DESCRIPTION
### Summary
Some of the footer links were pointing to old content or content that was not available anymore. This PR covers this by updating some of the links to the newer content and others to the new location.