### PR TITLE
#156 Disable query polling

### DIFF
--- a/apps/staking/__tests__/graphql/hooks/useBlocks.test.tsx
+++ b/apps/staking/__tests__/graphql/hooks/useBlocks.test.tsx
@@ -46,7 +46,6 @@ describe('useBlocks hook', () => {
                     node: undefined,
                 },
             },
-            pollInterval: 30000,
             notifyOnNetworkStatusChange: true,
         });
     });
@@ -71,7 +70,6 @@ describe('useBlocks hook', () => {
                 skip: 0,
                 count,
             },
-            pollInterval: 30000,
             notifyOnNetworkStatusChange: true,
         });
     });

--- a/apps/staking/__tests__/graphql/useStakingPools.test.tsx
+++ b/apps/staking/__tests__/graphql/useStakingPools.test.tsx
@@ -34,7 +34,6 @@ describe('useStakingPools', () => {
         expect(result.current.data).toHaveLength(3);
         expect(useQueryMock.mock.calls[0][1]).toEqual({
             notifyOnNetworkStatusChange: true,
-            pollInterval: 600000,
             variables: {
                 first: 50,
                 firstMonthlyPerf: 2,
@@ -72,7 +71,6 @@ describe('useStakingPools', () => {
         expect(result.current.data).toHaveLength(3);
         expect(useQueryMock.mock.calls[0][1]).toEqual({
             notifyOnNetworkStatusChange: true,
-            pollInterval: 600000,
             variables: {
                 first: 50,
                 firstMonthlyPerf: 2,

--- a/apps/staking/src/graphql/hooks/useBlocks.ts
+++ b/apps/staking/src/graphql/hooks/useBlocks.ts
@@ -26,7 +26,6 @@ const useBlocks = (where: BlocksWhere = {}, count = 100) => {
 
     return useQuery<BlocksData, BlocksVars>(BLOCKS, {
         variables,
-        pollInterval: 30000,
         notifyOnNetworkStatusChange: true,
     });
 };

--- a/apps/staking/src/graphql/hooks/useNodes.ts
+++ b/apps/staking/src/graphql/hooks/useNodes.ts
@@ -32,7 +32,6 @@ const useNodes = (
             orderDirection: 'desc',
         },
         notifyOnNetworkStatusChange: true,
-        pollInterval: 600000, // Every 10 minutes
     });
 };
 

--- a/apps/staking/src/graphql/hooks/usePoolActivities.ts
+++ b/apps/staking/src/graphql/hooks/usePoolActivities.ts
@@ -124,7 +124,6 @@ const usePoolActivities = ({
             first,
         },
         notifyOnNetworkStatusChange: true,
-        pollInterval: 600000,
     });
 
     useEffect(() => {

--- a/apps/staking/src/graphql/hooks/usePoolBalances.ts
+++ b/apps/staking/src/graphql/hooks/usePoolBalances.ts
@@ -56,7 +56,6 @@ const usePoolBalances = (
     perPage = POOLS_PER_PAGE,
     pool?: string
 ) => {
-    const tenMinutesInMs = 600000;
     const filter = {
         user: user?.toLowerCase() || undefined,
         pool: pool?.toLowerCase() || undefined,
@@ -71,7 +70,6 @@ const usePoolBalances = (
             orderDirection: 'desc',
         },
         notifyOnNetworkStatusChange: true,
-        pollInterval: tenMinutesInMs,
     });
 };
 

--- a/apps/staking/src/graphql/hooks/useStakingPool.ts
+++ b/apps/staking/src/graphql/hooks/useStakingPool.ts
@@ -19,7 +19,6 @@ const useStakingPool = (id: string): StakingPool => {
             id: id?.toLowerCase(),
         },
         notifyOnNetworkStatusChange: true,
-        pollInterval: 60000,
     });
 
     return data?.stakingPool;

--- a/apps/staking/src/graphql/hooks/useStakingPoolFeeHistories.ts
+++ b/apps/staking/src/graphql/hooks/useStakingPoolFeeHistories.ts
@@ -27,7 +27,6 @@ const useStakingPoolFeeHistories = (
     options: UseStakingPoolFeeHistoriesOptions
 ) => {
     const { pool = undefined, pageNumber = 0, perPage = 20 } = options;
-    const tenMinutesInMs = 600000;
     const filter: UseStakingPoolFeeHistoriesFilter = {};
 
     if (pool) {
@@ -46,7 +45,6 @@ const useStakingPoolFeeHistories = (
             orderDirection: 'desc',
         },
         notifyOnNetworkStatusChange: true,
-        pollInterval: tenMinutesInMs,
     });
 };
 

--- a/apps/staking/src/graphql/hooks/useStakingPoolPerformance.ts
+++ b/apps/staking/src/graphql/hooks/useStakingPoolPerformance.ts
@@ -25,7 +25,6 @@ const useStakingPoolPerformance = (address: string) => {
                     timestamp_gte: getPastDaysInSeconds(7),
                 },
             },
-            pollInterval: 60000,
         }
     );
 };

--- a/apps/staking/src/graphql/hooks/useStakingPoolUserHistories.ts
+++ b/apps/staking/src/graphql/hooks/useStakingPoolUserHistories.ts
@@ -38,7 +38,6 @@ const useStakingPoolUserHistories = (
         pageNumber = 0,
         perPage = 20,
     } = options;
-    const tenMinutesInMs = 600000;
     const filter: UseStakingPoolFeeHistoriesFilter = {
         timestamp_gte: toUnixTimestamp(startTimestamp),
         timestamp_lte: toUnixTimestamp(endTimestamp),
@@ -60,7 +59,6 @@ const useStakingPoolUserHistories = (
             orderDirection: 'asc',
         },
         notifyOnNetworkStatusChange: true,
-        pollInterval: tenMinutesInMs,
     });
 };
 

--- a/apps/staking/src/graphql/hooks/useStakingPools.ts
+++ b/apps/staking/src/graphql/hooks/useStakingPools.ts
@@ -89,7 +89,6 @@ const useStakingPools = ({
             },
         },
         notifyOnNetworkStatusChange: true,
-        pollInterval: 600000, // Every 10 minutes
     });
 };
 

--- a/apps/staking/src/graphql/hooks/useSummary.ts
+++ b/apps/staking/src/graphql/hooks/useSummary.ts
@@ -19,7 +19,6 @@ const useSummary = (): Summary => {
             id: '1',
         },
         notifyOnNetworkStatusChange: true,
-        pollInterval: 600000,
     });
     return data?.summary;
 };

--- a/apps/staking/src/graphql/hooks/useTotalPoolBalance.ts
+++ b/apps/staking/src/graphql/hooks/useTotalPoolBalance.ts
@@ -38,7 +38,6 @@ const useTotalPoolBalance = (user: string) => {
                 orderDirection: 'desc',
             },
             notifyOnNetworkStatusChange: true,
-            pollInterval: 600000,
         }
     );
 

--- a/apps/staking/src/graphql/hooks/useUser.ts
+++ b/apps/staking/src/graphql/hooks/useUser.ts
@@ -19,7 +19,6 @@ const useUser = (id: string) => {
             id: id?.toLowerCase(),
         },
         notifyOnNetworkStatusChange: true,
-        pollInterval: 60000,
     });
 
     return data?.user;

--- a/apps/staking/src/graphql/hooks/useUsers.ts
+++ b/apps/staking/src/graphql/hooks/useUsers.ts
@@ -20,7 +20,6 @@ const useUsers = (
     perPage = 10
 ) => {
     const filter = id ? { id: id.toLowerCase() } : {};
-    const tenMinutesInMs = 600000;
 
     return useQuery<UsersData, UsersVars>(USERS, {
         variables: {
@@ -31,7 +30,6 @@ const useUsers = (
             orderDirection: 'desc',
         },
         notifyOnNetworkStatusChange: true,
-        pollInterval: tenMinutesInMs,
     });
 };
 


### PR DESCRIPTION
## Summary

I removed the `pollInterval` setting for all graphql queries so that we are doing any http requests to the graphql BE only on page load. This can be easily noticed on the `/blocks` page, where we were previously polling a lot of data every 30 seconds.

I also checked the `useBlockNumber` custom hook that we have in `/staking/src/services/eth.tsx`. It is used on most of the pages and although it often causes re-renders in components that use it (because the block number changes every ~15 seconds), I didn't notice it causing any side effects like extra http requests happening. That's why I didn't make any changes in `useBlockNumber`.


## Testing Instructions

1. Build the app locally for dev env
2. Go to the `/` (home), or `/blocks` , or any other page where we were previously polling the graphql queries
3. Observe the network requests
4. Notice that no extra network requests for the page data are being made to the graphql BE after the page load 
