### PR TITLE
#168 Fix layout for pool settings

### DIFF
--- a/apps/staking/src/components/stake/PoolSetting.tsx
+++ b/apps/staking/src/components/stake/PoolSetting.tsx
@@ -299,6 +299,7 @@ export const PoolSetting: FC<PoolSettingsProps> = ({ address }) => {
                 justifySelf="flex-end"
                 justifyContent="flex-end"
                 alignItems="flex-end"
+                w="full"
                 mt={2}
             >
                 <TransactionBanner


### PR DESCRIPTION
## Summary

Small fix for the settings layout on the `/pools/{address}/manage` page.

## Testing Instructions

1. Connect your wallet.
2. Click the link node-runners in the header.
3. Click manage icon in a pool. PS: Create one if necessary.
4. Scroll down to the settings area.
5. You should be able to see the misaligned fields according to the screenshot.