### PR TITLE
Feat: Add Opts for useEns hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [3.9.0] - 2024-12-20
+## [3.9.0] - 2025-01-07
 
 -   Improve how the ENS address information is provided if available through the UI. The new approach considerably improves efficiency in terms of on-chain reads.
 

--- a/packages/ui/src/components/Address.tsx
+++ b/packages/ui/src/components/Address.tsx
@@ -68,7 +68,8 @@ const Address: FC<AddressProps> = (props) => {
     } = props;
 
     // resolve ENS entry from address
-    const addressEnsInfo = useENS(address);
+    const withEns = ens === true;
+    const addressEnsInfo = useENS(address, { enabled: withEns });
     const ensEntry = ens ? addressEnsInfo : null;
 
     const { hasCopied, onCopy } = useClipboard(address);


### PR DESCRIPTION
## Summary
Code changes are needed to add options to the `useENS` hook to control when to fetch or not fetch ENS information in some parts of the UI (It affects mainly when local-cache misses happen), i.e. no network calls. The **second** change is just an amendment to the Changelog release date. 