### PR TITLE
Feat: increase function execution time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.9.1] - 2025-01-08
+
+-   Increased only the execution duration for the function that handles the update of ENS entries marked as stale.
+
 ## [3.9.0] - 2025-01-07
 
--   Improve how the ENS address information is provided if available through the UI. The new approach considerably improves efficiency in terms of on-chain reads.
+-   Improved how the ENS address information is provided if available through the UI. The new approach considerably improves efficiency in terms of on-chain reads.
 
 ## [3.8.6] - 2024-12-05
 
@@ -396,7 +400,8 @@ Staking Pools
 
 -   First release
 
-[unreleased]: https://github.com/cartesi/explorer/compare/v3.9.0...HEAD
+[unreleased]: https://github.com/cartesi/explorer/compare/v3.9.1...HEAD
+[3.9.1]: https://github.com/cartesi/explorer/compare/v3.9.1...v3.9.0
 [3.9.0]: https://github.com/cartesi/explorer/compare/v3.9.0...v3.8.6
 [3.8.6]: https://github.com/cartesi/explorer/compare/v3.8.6...v3.8.5
 [3.8.5]: https://github.com/cartesi/explorer/compare/v3.8.5...v3.8.4

--- a/apps/staking/src/pages/api/cron/ens-update-stale.ts
+++ b/apps/staking/src/pages/api/cron/ens-update-stale.ts
@@ -20,6 +20,13 @@ const cronSecret = process.env.CRON_SECRET;
 const isAuthorized = (req: NextApiRequest) =>
     req.headers.authorization === `Bearer ${cronSecret}`;
 
+/**
+ * This function will be allowed to run for a maximum of 30 seconds.
+ */
+export const config = {
+    maxDuration: 30,
+};
+
 const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     if (!isAuthorized(req))
         return handleResponse({ ok: false, error: 'unauthorized' }, res);


### PR DESCRIPTION
## Summary
Code changes to increase the duration time on the function level. Only the API function handling the update of stale ENS entries will have a duration above the default 15 seconds on Vercel. 

The reason is that, looking at the logs, the call for the ENS graphQL takes a considerable portion of that duration limit 
varying between 7 ~ 11 s, plus the duration of avatar text checks **on-chain** may take around 4s ~ 6s passing the limit of 15s. 

These times are based on the current 742 entries marked as stale and needed to be checked. The graphQL query to ENS is a single call passing all the addresses of interest, so not much space for optimisation in that end (based on [the graph docs](https://thegraph.com/docs/en/subgraphs/querying/best-practices/#use-a-single-query-to-request-multiple-records)). So my assumption is more related to **where** the API function is running and the location of the ENS graphQL (Powered by TheGraph). I will add a few screenshots regarding the logs. 

_PS: Currently, our ENS storage has replicas in US / EU / APAC_

<details>
<summary><h3>Screenshots</h3></summary>

### First try (504 failure)
<img width="794" alt="image" src="https://github.com/user-attachments/assets/3c5898f6-c2b1-4ed5-afb9-3f524965f8fe" />

### Second try (504 failure)
<img width="807" alt="image" src="https://github.com/user-attachments/assets/0b1a6f4a-bb76-4a4e-b010-77b6cf199f80" />

### Third try (200 ok)
<img width="794" alt="image" src="https://github.com/user-attachments/assets/38fdb9af-44dd-4e99-a944-c649dddac1dc" />

</details>