### PR TITLE
#185 Fix users search

### DIFF
--- a/apps/staking/__tests__/hooks/useDebounce.test.ts
+++ b/apps/staking/__tests__/hooks/useDebounce.test.ts
@@ -1,0 +1,25 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { useDebounce } from '../../src/hooks/useDebounce';
+
+describe('Hooks/useDebounce', () => {
+    it('should debounce callback until a given delay has passed', async () => {
+        const callback = jest.fn();
+        const delay = 400;
+        const { result } = renderHook(() => useDebounce(callback, delay));
+
+        const functionInvocations = Array.from({ length: 4 }).map(
+            () =>
+                new Promise<void>((resolve) => {
+                    setTimeout(() => {
+                        result.current();
+                        resolve();
+                    }, 100);
+                })
+        );
+        await Promise.all(functionInvocations);
+
+        await waitFor(() => expect(callback).toHaveBeenCalledTimes(1), {
+            timeout: delay + 10,
+        });
+    });
+});

--- a/apps/staking/src/hooks/useDebounce.ts
+++ b/apps/staking/src/hooks/useDebounce.ts
@@ -1,0 +1,7 @@
+import { useCallback } from 'react';
+import { debounce } from 'lodash/fp';
+
+export const useDebounce = (callback: (args?: any) => void, delay = 500) => {
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- Lodash debounce needs to be set up like this in react context
+    return useCallback(debounce(delay, callback), []);
+};

--- a/apps/staking/src/pages/blocks/[[...block]].tsx
+++ b/apps/staking/src/pages/blocks/[[...block]].tsx
@@ -9,7 +9,7 @@
 // WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-import React, { FC, FunctionComponent, useState, useCallback } from 'react';
+import React, { FC, FunctionComponent, useState } from 'react';
 import { useRouter } from 'next/router';
 import {
     Button,
@@ -34,7 +34,7 @@ import BlockCard from '../../components/block/BlockCard';
 import SearchInput from '../../components/SearchInput';
 import PageHeader from '../../components/PageHeader';
 import PageHead from '../../components/PageHead';
-import { debounce } from 'lodash/fp';
+import { useDebounce } from '../../hooks/useDebounce';
 
 interface FilterProps {
     label: string;
@@ -124,6 +124,7 @@ const Blocks: FC<BlocksProps> = ({ chainId }) => {
     blockId = blockId && blockId.length > 0 ? (blockId[0] as string) : '';
 
     const [debouncedSearchKey, setDebouncedSearchKey] = useState(blockId);
+    const handleDebouncedSearch = useDebounce(setDebouncedSearchKey);
 
     // list of all blocks, unfiltered
     const all = useBlocks(undefined, 20);
@@ -135,14 +136,6 @@ const Blocks: FC<BlocksProps> = ({ chainId }) => {
     const byNode = useBlocks({ node: debouncedSearchKey }, 20);
     const pageBg = useColorModeValue('white', 'dark.gray.primary');
 
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- Lodash debounce needs to be set up like this in react context
-    const debounced = useCallback(
-        debounce(500, (nextValue: string) => {
-            setDebouncedSearchKey(nextValue);
-        }),
-        []
-    );
-
     return (
         <Layout>
             <PageHead title="Cartesi Proof of Stake Blocks" />
@@ -151,10 +144,9 @@ const Blocks: FC<BlocksProps> = ({ chainId }) => {
                 <SearchInput
                     w={[100, 200, 400, 400]}
                     placeholder="Search by producer"
-                    onSearchChange={(e) => {
-                        const nextValue = e.target.value;
-                        debounced(nextValue);
-                    }}
+                    onSearchChange={(e) =>
+                        handleDebouncedSearch(e.target.value)
+                    }
                 />
             </PageHeader>
 


### PR DESCRIPTION
## Summary

I fixed the issue by disabling pagination for the `usePoolBalances` hook, when a search is being performed.

Additionally, I added debounce for the users' search to reduce the load on the server. Since similar logic is utilised on the `blocks` page as well I extracted the debounce logic into a custom hook and covered it with a unit test, and refactored both pages to use that hook.

## Testing Instructions

Instructions can be found [here](https://github.com/cartesi/explorer/issues/185).
