### PR TITLE
Chore: Upgrade unleash sdk and proxy

### DIFF
--- a/apps/staking/__tests__/hooks/useDebounce.test.ts
+++ b/apps/staking/__tests__/hooks/useDebounce.test.ts
@@ -6,20 +6,10 @@ describe('Hooks/useDebounce', () => {
         const callback = jest.fn();
         const delay = 400;
         const { result } = renderHook(() => useDebounce(callback, delay));
+        ['h', 'he', 'hell', 'hello'].forEach((arg) => result.current(arg));
 
-        const functionInvocations = Array.from({ length: 4 }).map(
-            () =>
-                new Promise<void>((resolve) => {
-                    setTimeout(() => {
-                        result.current();
-                        resolve();
-                    }, 100);
-                })
-        );
-        await Promise.all(functionInvocations);
+        await waitFor(() => expect(callback).toHaveBeenCalledTimes(1));
 
-        await waitFor(() => expect(callback).toHaveBeenCalledTimes(1), {
-            timeout: delay + 10,
-        });
+        expect(callback).toHaveBeenCalledWith('hello');
     });
 });

--- a/apps/staking/jest.config.js
+++ b/apps/staking/jest.config.js
@@ -24,9 +24,6 @@ module.exports = {
         // Handle image imports
         // https://jestjs.io/docs/webpack#handling-static-assets
         '^.+\\.(png|jpg|jpeg|gif|webp|avif|ico|bmp|svg)$/i': `<rootDir>/__mocks__/fileMock.js`,
-
-        // Handle module aliases
-        uuid: '<rootDir>/../../node_modules/uuid/dist/umd/uuid.min.js',
     },
     testMatch: [
         '**/__tests__/**/?(*.)+(spec|test).[jt]s?(x)',

--- a/package.json
+++ b/package.json
@@ -40,12 +40,12 @@
         "@chakra-ui/theme-tools": "2.0.12",
         "@emotion/react": "11.11.1",
         "@emotion/styled": "11.11.0",
-        "@unleash/proxy-client-react": "3.6.0",
+        "@unleash/proxy-client-react": "^4.5.1",
         "framer-motion": "10.13.0",
         "lcov-result-merger": "4.1.0",
         "react": "18.3.1",
         "react-dom": "18.3.1",
-        "unleash-proxy-client": "2.5.0"
+        "unleash-proxy-client": "^3.7.2"
     },
     "packageManager": "yarn@1.22.19"
 }

--- a/packages/ui/jest.config.js
+++ b/packages/ui/jest.config.js
@@ -20,9 +20,6 @@ module.exports = {
         // Handle image imports
         // https://jestjs.io/docs/webpack#handling-static-assets
         '^.+\\.(png|jpg|jpeg|gif|webp|avif|ico|bmp|svg)$/i': `<rootDir>/__mocks__/fileMock.js`,
-
-        // Handle module aliases
-        uuid: '<rootDir>/../../node_modules/uuid/dist/umd/uuid.min.js',
     },
     testMatch: [
         '**/__tests__/**/?(*.)+(spec|test).[jt]s?(x)',

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -34,7 +34,7 @@
         "@explorer/utils": "*",
         "@safe-global/safe-apps-provider": "^0.18.5",
         "@safe-global/safe-apps-sdk": "^9.1.0",
-        "@unleash/proxy-client-react": "3.6.0",
+        "@unleash/proxy-client-react": "^4.5.1",
         "@web3-onboard/coinbase": "^2.4.1",
         "@web3-onboard/core": "^2.23.1",
         "@web3-onboard/gnosis": "^2.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8341,10 +8341,10 @@
     "@typescript-eslint/types" "5.48.0"
     eslint-visitor-keys "^3.3.0"
 
-"@unleash/proxy-client-react@3.6.0":
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/@unleash/proxy-client-react/-/proxy-client-react-3.6.0.tgz#50e56abf6e1e2a02b53f17787b96462258b55901"
-  integrity sha512-maQ3PYdBWUpIraD9z/2C8oVoCAS/EryV0WT4HiZQWxzrwvrZ+XHQJw1sImzRdWlGMvl1qJcgdEoxXhNSuYIrEQ==
+"@unleash/proxy-client-react@^4.5.1":
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/@unleash/proxy-client-react/-/proxy-client-react-4.5.1.tgz#35d64afcea0b83c53354ef830818dd5dc23eee3d"
+  integrity sha512-vo9fcAbSM7SItBF0XuKqD/nderEfXCA5EC30ozm1HHWZr2tE4RxodsN26Nh1rGqgDkNVr2MssMX13p9G4P2aSw==
 
 "@use-it/event-listener@^0.1.2":
   version "0.1.7"
@@ -25695,13 +25695,13 @@ universalify@^2.0.0:
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
   integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
 
-unleash-proxy-client@2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/unleash-proxy-client/-/unleash-proxy-client-2.5.0.tgz#0f4f34285bc3223023ca2cf3ef9dabd2132eea9f"
-  integrity sha512-GWYLcQDW2UVhqAVwZX7jNzD6Lp96UJXEi66r9MiDd/C3Xw7rbTdFziNJAhEZpLNqR7j75+TfZaEYMCMy/k778g==
+unleash-proxy-client@^3.7.2:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/unleash-proxy-client/-/unleash-proxy-client-3.7.2.tgz#c6166bbaf293f8dea12cf65d061d72234c5b76a8"
+  integrity sha512-1SvHsl3kQh1DT9EKMQsN9alOvXZEz9hpxa3mG6QWtTmXJqa6VZi25dQ2U8Y2KAULKg6ARLMUQkod74Fe/pKp0g==
   dependencies:
     tiny-emitter "^2.1.0"
-    uuid "^8.3.2"
+    uuid "^9.0.1"
 
 unorm@^1.3.3:
   version "1.6.0"
@@ -25968,7 +25968,7 @@ uuid@^8.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
-uuid@^9.0.0:
+uuid@^9.0.0, uuid@^9.0.1:
   version "9.0.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
   integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==


### PR DESCRIPTION
## Summary
Code changes to bump unleash sdk and proxy libs to its latest. Also, I removed a Jest setup for module-name-mapper related to `uuid` lib; it is not necessary anymore. I did an unrelated code change to a test case for the `useDebounce` tests. It was unstable as it was failing and passing from run to run (screenshot below). 

Changes: 
* Upgrade the Unleash sdk and proxy-client-react libs `explorer` and `packages/wallet`. 
* Remove unnecessary module-name-mapping for Jest configs `apps/staking` and `packages/ui`
* Update test case for `useDebounce` hook.

**ps: Tested on safe-global app.**

<details>
<summary><h3>Test failure message</h3></summary


![Screenshot 2025-01-27 at 15 29 17](https://github.com/user-attachments/assets/7521b022-4eb7-47d8-969d-995b43703341)
</details>

