### PR TITLE
Feat: improve behaviour to deal with stale entries (refreshEntries() service call)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -23,6 +23,7 @@
         "@typescript-eslint/no-explicit-any": "off",
         "@typescript-eslint/explicit-module-boundary-types": "off",
         "@typescript-eslint/no-unnecessary-type-constraint": "off",
+        "@typescript-eslint/ban-ts-comment": "warn",
         "react/react-in-jsx-scope": "off",
         "react/no-children-prop": "warn",
         "react-hooks/rules-of-hooks": "warn",

--- a/__tests__/services/server/functions.test.ts
+++ b/__tests__/services/server/functions.test.ts
@@ -1,0 +1,180 @@
+// Copyright (C) 2025 Cartesi Pte. Ltd.
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free Software
+// Foundation, either version 3 of the License, or (at your option) any later
+// version.
+
+// This program is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+// PARTICULAR PURPOSE. See the GNU General Public License for more details.
+import { ApolloQueryResult } from '@apollo/client';
+import { ethers } from 'ethers';
+import { GetEnsDomainsQuery } from '../../../src/graphql/queries/ensDomains';
+import client from '../../../src/services/apolloENSClient';
+import { getENSData } from '../../../src/services/server/ens/functions';
+import { QueriedDomain } from '../../../src/services/server/ens/types';
+
+jest.mock('ethers');
+jest.mock('../../../src/services/apolloENSClient', () => {
+    return {
+        __esModule: true,
+        default: {
+            query: jest.fn(),
+        },
+    };
+});
+
+const providerMock = jest.mocked(ethers.providers.JsonRpcProvider);
+const clientMock = jest.mocked(client, { shallow: true });
+
+const createAvatarUrlResolver = (url: string) => {
+    const address = '0x002';
+    const name = 'resolver';
+    const provider = new ethers.providers.BaseProvider(11155111);
+
+    return {
+        getText: async () => url,
+        name,
+        address,
+        provider,
+        _fetchBytes: async () => address,
+        _getAddress(coinType, hexBytes) {
+            return '';
+        },
+        getAddress: async () => address,
+        getContentHash: async () => '',
+    } as ethers.providers.Resolver;
+};
+
+const buildENSResponse = () => [
+    {
+        createdAt: 1740987259,
+        id: '1',
+        name: 'my-pool',
+        resolvedAddress: {
+            id: validAddress,
+        },
+    },
+];
+
+const setENSQueryReturn = (list: QueriedDomain[]) => {
+    clientMock.query.mockResolvedValue({
+        data: { domains: list },
+    } as ApolloQueryResult<GetEnsDomainsQuery>);
+};
+
+const validAddress = '0x07b41c2b437e69dd1523bf1cff5de63ad9bb3dc6';
+
+describe('getENSData', () => {
+    const errorLog = jest.fn();
+    const infoLog = jest.fn();
+    const entry = { address: validAddress };
+    beforeEach(() => {
+        const resolver = createAvatarUrlResolver('');
+        providerMock.prototype.getResolver.mockResolvedValue(resolver);
+        setENSQueryReturn([]);
+
+        jest.spyOn(console, 'info').mockImplementation(infoLog);
+        jest.spyOn(console, 'time').mockImplementation(jest.fn());
+        jest.spyOn(console, 'timeEnd').mockImplementation(jest.fn());
+        jest.spyOn(console, 'error').mockImplementation(errorLog);
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should include ENS status even for address without registration', async () => {
+        const entry = { address: validAddress };
+        const [ensAddressData] = await getENSData([entry]);
+
+        expect(ensAddressData).toEqual({
+            address: validAddress,
+            hasEns: false,
+        });
+    });
+
+    it('should set the name when returned from ENS service', async () => {
+        setENSQueryReturn([
+            {
+                createdAt: 1740987259,
+                id: '1',
+                name: 'my-pool',
+                resolvedAddress: {
+                    id: validAddress,
+                },
+            },
+        ]);
+        const [expectedData] = await getENSData([entry]);
+
+        expect(expectedData).toHaveProperty('name', 'my-pool');
+        expect(expectedData).toHaveProperty('hasEns', true);
+        expect(expectedData).toHaveProperty('avatarUrl', '');
+    });
+
+    it('should search and update the avatar-url when the name is set', async () => {
+        setENSQueryReturn(buildENSResponse());
+        const resolver = createAvatarUrlResolver('https://host.com/avatar.png');
+        providerMock.prototype.getResolver.mockResolvedValue(resolver);
+
+        const [expectedData] = await getENSData([entry]);
+
+        expect(expectedData).toHaveProperty('name', 'my-pool');
+        expect(expectedData).toHaveProperty('hasEns', true);
+        expect(expectedData).toHaveProperty(
+            'avatarUrl',
+            'https://host.com/avatar.png'
+        );
+    });
+
+    it('should skip the avatar lookup when ENS information is not available', async () => {
+        const resolver = createAvatarUrlResolver('');
+        resolver.getText = jest.fn();
+        providerMock.prototype.getResolver.mockResolvedValue(resolver);
+
+        const [expectedData] = await getENSData([entry]);
+
+        expect(expectedData).toEqual({
+            hasEns: false,
+            address: validAddress,
+        });
+        expect(resolver.getText).not.toHaveBeenCalled();
+    });
+
+    it('should handle any error when searching domains and skip avatar-url search', async () => {
+        clientMock.query.mockRejectedValue(new Error('graphql-mock-error'));
+        const [expectedData] = await getENSData([entry]);
+
+        expect(expectedData).toStrictEqual({
+            address: validAddress,
+            hasEns: false,
+        });
+        expect(errorLog).toHaveBeenCalledTimes(1);
+        expect(errorLog.mock.calls[0][0]).toHaveProperty(
+            'message',
+            'graphql-mock-error'
+        );
+    });
+
+    it('should handle any error when searching for an avatar-url', async () => {
+        const getText = jest
+            .fn()
+            .mockRejectedValue(new Error('no name found!'));
+        setENSQueryReturn(buildENSResponse());
+        const resolver = createAvatarUrlResolver('');
+        resolver.getText = getText;
+        providerMock.prototype.getResolver.mockResolvedValue(resolver);
+
+        const [expectedData] = await getENSData([entry]);
+        expect(expectedData).toEqual({
+            address: validAddress,
+            avatarUrl: null,
+            hasEns: true,
+            name: 'my-pool',
+        });
+        expect(errorLog).toHaveBeenCalledTimes(1);
+        expect(errorLog.mock.calls[0][0]).toEqual(
+            'GET_AVATAR_URL: (my-pool) => Fail to get avatar.\nReason: no name found!'
+        );
+    });
+});

--- a/__tests__/services/server/functions.test.ts
+++ b/__tests__/services/server/functions.test.ts
@@ -11,7 +11,10 @@ import { ApolloQueryResult } from '@apollo/client';
 import { ethers } from 'ethers';
 import { GetEnsDomainsQuery } from '../../../src/graphql/queries/ensDomains';
 import client from '../../../src/services/apolloENSClient';
-import { getENSData } from '../../../src/services/server/ens/functions';
+import {
+    getENSData,
+    getFreshENSData,
+} from '../../../src/services/server/ens/functions';
 import { QueriedDomain } from '../../../src/services/server/ens/types';
 
 jest.mock('ethers');
@@ -65,7 +68,7 @@ const setENSQueryReturn = (list: QueriedDomain[]) => {
 
 const validAddress = '0x07b41c2b437e69dd1523bf1cff5de63ad9bb3dc6';
 
-describe('getENSData', () => {
+describe('ENS Functions', () => {
     const errorLog = jest.fn();
     const infoLog = jest.fn();
     const entry = { address: validAddress };
@@ -82,99 +85,183 @@ describe('getENSData', () => {
 
     afterEach(() => {
         jest.clearAllMocks();
+        errorLog.mockRestore();
+        infoLog.mockRestore();
     });
 
-    it('should include ENS status even for address without registration', async () => {
-        const entry = { address: validAddress };
-        const [ensAddressData] = await getENSData([entry]);
+    describe('getENSData', () => {
+        it('should include ENS status even for address without registration', async () => {
+            const entry = { address: validAddress };
+            const {
+                data: [ensAddressData],
+            } = await getENSData([entry]);
 
-        expect(ensAddressData).toEqual({
-            address: validAddress,
-            hasEns: false,
+            expect(ensAddressData).toEqual({
+                address: validAddress,
+                hasEns: false,
+            });
         });
-    });
 
-    it('should set the name when returned from ENS service', async () => {
-        setENSQueryReturn([
-            {
-                createdAt: 1740987259,
-                id: '1',
-                name: 'my-pool',
-                resolvedAddress: {
-                    id: validAddress,
+        it('should set the name when returned from ENS service', async () => {
+            setENSQueryReturn([
+                {
+                    createdAt: 1740987259,
+                    id: '1',
+                    name: 'my-pool',
+                    resolvedAddress: {
+                        id: validAddress,
+                    },
                 },
-            },
-        ]);
-        const [expectedData] = await getENSData([entry]);
+            ]);
+            const {
+                data: [expectedData],
+            } = await getENSData([entry]);
 
-        expect(expectedData).toHaveProperty('name', 'my-pool');
-        expect(expectedData).toHaveProperty('hasEns', true);
-        expect(expectedData).toHaveProperty('avatarUrl', '');
-    });
-
-    it('should search and update the avatar-url when the name is set', async () => {
-        setENSQueryReturn(buildENSResponse());
-        const resolver = createAvatarUrlResolver('https://host.com/avatar.png');
-        providerMock.prototype.getResolver.mockResolvedValue(resolver);
-
-        const [expectedData] = await getENSData([entry]);
-
-        expect(expectedData).toHaveProperty('name', 'my-pool');
-        expect(expectedData).toHaveProperty('hasEns', true);
-        expect(expectedData).toHaveProperty(
-            'avatarUrl',
-            'https://host.com/avatar.png'
-        );
-    });
-
-    it('should skip the avatar lookup when ENS information is not available', async () => {
-        const resolver = createAvatarUrlResolver('');
-        resolver.getText = jest.fn();
-        providerMock.prototype.getResolver.mockResolvedValue(resolver);
-
-        const [expectedData] = await getENSData([entry]);
-
-        expect(expectedData).toEqual({
-            hasEns: false,
-            address: validAddress,
+            expect(expectedData).toHaveProperty('name', 'my-pool');
+            expect(expectedData).toHaveProperty('hasEns', true);
+            expect(expectedData).toHaveProperty('avatarUrl', '');
         });
-        expect(resolver.getText).not.toHaveBeenCalled();
+
+        it('should search and update the avatar-url when the name is set', async () => {
+            setENSQueryReturn(buildENSResponse());
+            const resolver = createAvatarUrlResolver(
+                'https://host.com/avatar.png'
+            );
+            providerMock.prototype.getResolver.mockResolvedValue(resolver);
+
+            const {
+                data: [expectedData],
+            } = await getENSData([entry]);
+
+            expect(expectedData).toHaveProperty('name', 'my-pool');
+            expect(expectedData).toHaveProperty('hasEns', true);
+            expect(expectedData).toHaveProperty(
+                'avatarUrl',
+                'https://host.com/avatar.png'
+            );
+        });
+
+        it('should skip the avatar lookup when ENS information is not available', async () => {
+            const resolver = createAvatarUrlResolver('');
+            resolver.getText = jest.fn();
+            providerMock.prototype.getResolver.mockResolvedValue(resolver);
+
+            const {
+                state,
+                data: [expectedData],
+            } = await getENSData([entry]);
+
+            expect(state).toEqual('ok');
+            expect(expectedData).toEqual({
+                hasEns: false,
+                address: validAddress,
+            });
+            expect(resolver.getText).not.toHaveBeenCalled();
+        });
+
+        it('should handle any error when searching domains and skip avatar-url search', async () => {
+            clientMock.query.mockRejectedValue(new Error('graphql-mock-error'));
+            const {
+                state,
+                data: [expectedData],
+            } = await getENSData([entry]);
+
+            expect(state).toEqual('ens_query_failed');
+            expect(expectedData).toStrictEqual({
+                address: validAddress,
+                hasEns: false,
+            });
+            expect(errorLog).toHaveBeenCalledTimes(1);
+            expect(errorLog.mock.calls[0][0]).toHaveProperty(
+                'message',
+                'graphql-mock-error'
+            );
+        });
+
+        it('should log and continue when an error occur when searching for an avatar-url', async () => {
+            const getText = jest
+                .fn()
+                .mockRejectedValue(new Error('no name found!'));
+            setENSQueryReturn(buildENSResponse());
+            const resolver = createAvatarUrlResolver('');
+            resolver.getText = getText;
+            providerMock.prototype.getResolver.mockResolvedValue(resolver);
+
+            const {
+                state,
+                data: [expectedData],
+            } = await getENSData([entry]);
+
+            expect(state).toEqual('ok');
+            expect(expectedData).toEqual({
+                address: validAddress,
+                avatarUrl: null,
+                hasEns: true,
+                name: 'my-pool',
+            });
+
+            expect(errorLog).toHaveBeenCalledTimes(1);
+            expect(errorLog.mock.calls[0][0]).toEqual(
+                'GET_AVATAR_URL: (my-pool) => Fail to get avatar.\nReason: no name found!'
+            );
+        });
     });
 
-    it('should handle any error when searching domains and skip avatar-url search', async () => {
-        clientMock.query.mockRejectedValue(new Error('graphql-mock-error'));
-        const [expectedData] = await getENSData([entry]);
+    describe('getFreshENSData', () => {
+        it('should partition request when entries are above the limit', async () => {
+            setENSQueryReturn([
+                {
+                    createdAt: 1740987259,
+                    id: '1',
+                    name: 'my-pool',
+                    resolvedAddress: {
+                        id: validAddress,
+                    },
+                },
+            ]);
+            const resolver = createAvatarUrlResolver(
+                'http://host.com/avatar.png'
+            );
+            providerMock.prototype.getResolver.mockResolvedValue(resolver);
 
-        expect(expectedData).toStrictEqual({
-            address: validAddress,
-            hasEns: false,
+            const dummyStaleEntry = { ...entry, hasEns: false };
+
+            const expectedPayloads = await getFreshENSData([
+                { ...dummyStaleEntry, id: 1 },
+                { ...dummyStaleEntry, id: 2 },
+                { ...dummyStaleEntry, id: 3 },
+            ]);
+
+            const expectedDummyData = {
+                ...entry,
+                avatarUrl: 'http://host.com/avatar.png',
+                hasEns: true,
+                name: 'my-pool',
+            };
+
+            expect(expectedPayloads.length).toEqual(2);
+            expect(expectedPayloads[0]).toEqual({
+                state: 'ok',
+                data: [
+                    { ...expectedDummyData, id: 1 },
+                    { ...expectedDummyData, id: 2 },
+                ],
+            });
+            expect(expectedPayloads[1]).toEqual({
+                state: 'ok',
+                data: [{ ...expectedDummyData, id: 3 }],
+            });
+
+            expect(infoLog).toHaveBeenCalledTimes(10);
+            expect(infoLog.mock.calls[0][0]).toEqual(
+                '(GET_FRESH_ENS_DATA): Maximum items per request 2'
+            );
+            expect(infoLog.mock.calls[1][0]).toEqual(
+                '(GET_FRESH_ENS_DATA): Total stale entries to check 3'
+            );
+            expect(infoLog.mock.calls[2][0]).toEqual(
+                '(GET_FRESH_ENS_DATA): Breaking into 2 concurrent calls'
+            );
         });
-        expect(errorLog).toHaveBeenCalledTimes(1);
-        expect(errorLog.mock.calls[0][0]).toHaveProperty(
-            'message',
-            'graphql-mock-error'
-        );
-    });
-
-    it('should handle any error when searching for an avatar-url', async () => {
-        const getText = jest
-            .fn()
-            .mockRejectedValue(new Error('no name found!'));
-        setENSQueryReturn(buildENSResponse());
-        const resolver = createAvatarUrlResolver('');
-        resolver.getText = getText;
-        providerMock.prototype.getResolver.mockResolvedValue(resolver);
-
-        const [expectedData] = await getENSData([entry]);
-        expect(expectedData).toEqual({
-            address: validAddress,
-            avatarUrl: null,
-            hasEns: true,
-            name: 'my-pool',
-        });
-        expect(errorLog).toHaveBeenCalledTimes(1);
-        expect(errorLog.mock.calls[0][0]).toEqual(
-            'GET_AVATAR_URL: (my-pool) => Fail to get avatar.\nReason: no name found!'
-        );
     });
 });

--- a/additional.d.ts
+++ b/additional.d.ts
@@ -55,6 +55,13 @@ declare namespace NodeJS {
         HTTP_MAINNET_NODE_RPC: string;
 
         /**
+         * Maximum number of entries per request when fetching ENS information. It is configurable but default and maximum is 900 entries.
+         * Therefore, the number here dictates the relation between entries-limit and concurrent calls to be created when this limit is exceeded.
+         * @default 900
+         */
+        ENS_ENTRIES_PER_REQ_LIMIT: string;
+
+        /**
          * should be a number that set when ENS information about an address
          * is considered staled.
          */

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -4,6 +4,8 @@ import '@testing-library/jest-dom/extend-expect';
 import 'jest-canvas-mock';
 import { TextDecoder, TextEncoder } from 'util';
 
+process.env.ENS_ENTRIES_PER_REQ_LIMIT = 2;
+
 Object.assign(global, { TextEncoder, TextDecoder });
 
 jest.mock('./src/services/ens', () => {

--- a/src/services/server/ens/functions.ts
+++ b/src/services/server/ens/functions.ts
@@ -143,11 +143,15 @@ const addENSName = async (entries: Entry[]): Promise<ENSAddressData[]> => {
 
     const result = entries.map((entry) => {
         const ensInfo = domainsByAddress[entry.address];
-        return {
+        const name = ensInfo?.name || ensInfo?.labelName;
+        const newEntry: ENSAddressData = {
             ...entry,
             hasEns: ensInfo !== undefined,
-            name: ensInfo?.name || ensInfo?.labelName,
         };
+
+        if (name) newEntry.name = name;
+
+        return newEntry;
     });
 
     console.timeEnd(timeLabel);

--- a/src/services/server/ens/functions.ts
+++ b/src/services/server/ens/functions.ts
@@ -16,7 +16,24 @@ import {
 } from '../../../graphql/queries/ensDomains';
 import { Network } from '../../../utils/networks';
 import ensClient from '../../apolloENSClient';
-import { ENSAddressData, Entry, QueriedDomain } from './types';
+import { ENSAddressData, Entry, QueriedDomain, StaleEntry } from './types';
+import defaultTo from 'lodash/fp/defaultTo';
+
+type GetDomainsResult = Record<string, QueriedDomain>;
+type PayloadState = 'ok' | 'ens_query_failed';
+type ENSPayload = {
+    state: PayloadState;
+    data: ENSAddressData[];
+};
+
+const defaultMaxEntriesPerReqLimit = 900 as const;
+const MAX_ENTRIES_PER_REQ = Math.min(
+    defaultMaxEntriesPerReqLimit,
+    defaultTo(
+        defaultMaxEntriesPerReqLimit,
+        parseInt(process.env.ENS_ENTRIES_PER_REQ_LIMIT ?? '')
+    )
+);
 
 const httpNodeRpc =
     process.env.HTTP_MAINNET_NODE_RPC ?? 'https://cloudflare-eth.com';
@@ -37,6 +54,7 @@ const ACTION_NAME = {
     getDomains: 'GET_DOMAINS',
     addENSName: 'ADD_ENS_NAME',
     getAvatarUrl: 'GET_AVATAR_URL',
+    getFreshENSData: 'GET_FRESH_ENS_DATA',
 } as const;
 
 const getAvatarUrl = (name: string): Promise<string | null> => {
@@ -53,12 +71,13 @@ const getAvatarUrl = (name: string): Promise<string | null> => {
         });
 };
 
-const addAvatarUrl = async (
-    ensAddressDataList: ENSAddressData[]
-): Promise<ENSAddressData[]> => {
-    const timeLabel = `${ACTION_NAME.addAvatarUrl}(${ensAddressDataList.length})`;
+const addAvatarUrl = async (ensPayload: ENSPayload): Promise<ENSPayload> => {
+    // skip any L1 resolver checks, as the primary query failed.
+    if (ensPayload.state === 'ens_query_failed') return ensPayload;
+
+    const timeLabel = `${ACTION_NAME.addAvatarUrl}(${ensPayload.data.length})`;
     console.time(timeLabel);
-    const listP = ensAddressDataList.map((ensAddressData) => {
+    const listP = ensPayload.data.map((ensAddressData) => {
         if (
             !ensAddressData.hasEns ||
             (ensAddressData.hasEns && !ensAddressData.name)
@@ -76,41 +95,40 @@ const addAvatarUrl = async (
             })
             .catch((reason: any) => {
                 console.error(
-                    `${ACTION_NAME}: (Errored) ${ensAddressData.address} - reason (${reason.message})`
+                    `${ACTION_NAME.addAvatarUrl}: (Errored) ${ensAddressData.address} - reason (${reason.message})`
                 );
                 return ensAddressData;
             });
     });
 
-    const result = await Promise.all(listP);
+    const data = await Promise.all(listP);
     console.timeEnd(timeLabel);
 
-    return result;
+    return { state: 'ok', data };
 };
 
-const getDomains = async (addresses: string[]) => {
+const getDomains = async (addresses: string[]): Promise<GetDomainsResult> => {
     const timeLabel = `${ACTION_NAME.getDomains}(${addresses.length})`;
     console.time(timeLabel);
-    const result = await ensClient
-        .query<GetEnsDomainsQuery>({
-            query: DOMAINS,
-            variables: {
-                first: addresses.length,
-                where: { resolvedAddress_in: addresses },
-                orderBy: 'createdAt',
-                orderDirection: 'asc',
-            },
-        })
-        .catch((reason: any) => {
-            console.error(reason);
-            return {
-                data: {
-                    domains: [],
-                },
-            };
-        });
+    const result = await ensClient.query<GetEnsDomainsQuery>({
+        query: DOMAINS,
+        variables: {
+            first: addresses.length,
+            where: { resolvedAddress_in: addresses },
+            orderBy: 'createdAt',
+            orderDirection: 'asc',
+        },
+    });
 
-    const domains = (result.data.domains ?? []) as QueriedDomain[];
+    const domains = result.data.domains ?? [];
+    const domainsByAddress = domains.reduce((prev, curr) => {
+        const address = curr.resolvedAddress?.id ?? '';
+        return {
+            ...prev,
+            [address]: curr,
+        };
+    }, {} as GetDomainsResult);
+
     console.info(
         `${ACTION_NAME.getDomains}: (Number of addresses): ${addresses.length}`
     );
@@ -119,29 +137,29 @@ const getDomains = async (addresses: string[]) => {
     );
 
     console.timeEnd(timeLabel);
-    return domains;
+
+    return domainsByAddress;
 };
 
-const getDomainsByAddress = (domains: QueriedDomain[]) => {
-    return domains.reduce((prev, curr) => {
-        const address = curr.resolvedAddress?.id ?? '';
-        return {
-            ...prev,
-            [address]: curr,
-        };
-    }, {} as Record<string, QueriedDomain>);
-};
-
-const addENSName = async (entries: Entry[]): Promise<ENSAddressData[]> => {
+const addENSName = async (entries: Entry[]): Promise<ENSPayload> => {
+    if (!entries || (entries && entries.length === 0))
+        return { state: 'ok', data: [] };
     const timeLabel = `${ACTION_NAME.addENSName}(${entries.length})`;
     console.time(timeLabel);
-    if (!entries || (entries && entries.length === 0)) return [];
 
-    const addresses = entries.map((e) => e.address);
-    const domains = await getDomains(addresses);
-    const domainsByAddress = getDomainsByAddress(domains);
+    let state: PayloadState = 'ok';
+    let domainsByAddress: GetDomainsResult;
 
-    const result = entries.map((entry) => {
+    try {
+        const addresses = entries.map((e) => e.address);
+        domainsByAddress = await getDomains(addresses);
+    } catch (error: any) {
+        console.error(error);
+        state = 'ens_query_failed';
+        domainsByAddress = {};
+    }
+
+    const data = entries.map((entry) => {
         const ensInfo = domainsByAddress[entry.address];
         const name = ensInfo?.name || ensInfo?.labelName;
         const newEntry: ENSAddressData = {
@@ -156,9 +174,33 @@ const addENSName = async (entries: Entry[]): Promise<ENSAddressData[]> => {
 
     console.timeEnd(timeLabel);
 
-    return result;
+    return { state, data };
 };
 
 export const getENSData = async (entries: Entry[]) => {
     return addENSName(entries).then(addAvatarUrl);
+};
+
+/**
+ * Receive a list of N entries and break into Y partitions of limited number of entries.
+ * The Y partitions is the number of concurrent requests to be sent.
+ * The return is a list of Y ENS-payloads.
+ *
+ * @returns {Promise<ENSPayload[]>}
+ */
+export const getFreshENSData = async (staleList: StaleEntry[]) => {
+    const partitions = Math.ceil(staleList.length / MAX_ENTRIES_PER_REQ);
+    const promises: Promise<ENSPayload>[] = [];
+    const label = `(${ACTION_NAME.getFreshENSData})`;
+    console.info(`${label}: Maximum items per request ${MAX_ENTRIES_PER_REQ}`);
+    console.info(`${label}: Total stale entries to check ${staleList.length}`);
+    console.info(`${label}: Breaking into ${partitions} concurrent calls`);
+
+    for (let i = 1; i <= partitions; i++) {
+        promises.push(getENSData(staleList.splice(0, MAX_ENTRIES_PER_REQ)));
+    }
+
+    const payloads = await Promise.all(promises);
+
+    return payloads;
 };

--- a/src/services/server/ens/types.ts
+++ b/src/services/server/ens/types.ts
@@ -10,6 +10,7 @@
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
 import { GetEnsDomainsQuery } from '../../../graphql/queries/ensDomains';
+import AddressENSRepository from './AddressENSRepository';
 
 export type AddressEns = {
     id: number;
@@ -18,8 +19,6 @@ export type AddressEns = {
     name?: string;
     avatarUrl?: string;
 };
-
-export type StaleEntry = Pick<AddressEns, 'id' | 'address'>;
 
 export type Entry = {
     id?: number;
@@ -34,3 +33,7 @@ export type ENSAddressData = {
     name?: string | null;
     avatarUrl?: string | null;
 };
+
+export type StaleEntry = Awaited<
+    ReturnType<typeof AddressENSRepository.getAllStaleEntries>
+>[number];


### PR DESCRIPTION
### Summary
Code changes to handle a large number of entries to refresh and improve the decision when to or not to refresh entries depending on responses from important third-party (i.e. ENS Subgraph). 

_PS: Currently, the cronjob is turned off._ 

**Summary:**
- Added a new function to deal with refreshing existing data specifically. Located on `ens/functions.ts`, it will create partitions in case the number of items is bigger than a certain limit when querying ENS Subgraph service. 
- Added environment variable to set the limit of entries per request. The current default and maximum value is 900 items. It can be configured to be lower, but that defines the ratio between items/requests; the smaller the number of items, it will likely increase the number of concurrent requests to be sent. The production target is the `default`; **that number is not magical and is just 100 items below the limit of 1000 per subgraph query.**
- For both functions `getENSData` and `getFreshENSData`, it now works with a `payload` structure with a **state** and **data** property, and the caller will deal with the results accordingly.
- The `refreshEntries` service method, in case of any payload with a state different from `ok`, will discard the payload rather than override the current values, leaving it to be rechecked in the next cronjob rotation.
- No changes are necessary to the frontend, only backend refactorings to add the new payload passing and error handling.
- Logs added, so we check on what is going on as data is flowing through. 


ps²: Once merged and released, I will turn on the cronjobs again. 
