### PR TITLE
feat: Add speed insights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.10.1] - 2025-04-15
+
+-   Added Vercel speed metrics library. The previous way of acquiring information about the speed of the web application was deprecated.
+
 ## [3.10.0] - 2025-03-12
 
 -   Improve behaviour when refreshing stale address ENS information.
@@ -420,7 +424,8 @@ Staking Pools
 
 -   First release
 
-[unreleased]: https://github.com/cartesi/explorer/compare/v3.10.0...HEAD
+[unreleased]: https://github.com/cartesi/explorer/compare/v3.10.1...HEAD
+[3.10.1]: https://github.com/cartesi/explorer/compare/v3.10.1...v3.10.0
 [3.10.0]: https://github.com/cartesi/explorer/compare/v3.10.0...v3.9.4
 [3.9.4]: https://github.com/cartesi/explorer/compare/v3.9.4...v3.9.3
 [3.9.3]: https://github.com/cartesi/explorer/compare/v3.9.3...v3.9.2

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
         "@safe-global/safe-apps-sdk": "^9.1.0",
         "@types/humanize-duration": "3.25.1",
         "@unleash/proxy-client-react": "^4.5.1",
+        "@vercel/speed-insights": "^1.2.0",
         "@web3-onboard/coinbase": "^2.4.1",
         "@web3-onboard/core": "^2.23.1",
         "@web3-onboard/gnosis": "^2.3.2",

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -10,18 +10,18 @@
 // PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
 import { ChakraProvider } from '@chakra-ui/react';
+import { SpeedInsights } from '@vercel/speed-insights/next';
 import { AppProps } from 'next/app';
 import dynamic from 'next/dynamic';
 import { FC, ReactNode, useEffect, useState } from 'react';
 import TagManager from 'react-gtm-module';
 import ApolloContainer from '../components/ApolloContainer';
-import theme from '../styles/theme';
-
 import { Fonts } from '../components/Fonts';
 import PageHead from '../components/PageHead';
 import { GA4TrackerProvider } from '../contexts/ga4Tracker';
 import { ENSDataProvider } from '../services/ens';
 import { AddressEns } from '../services/server/ens/types';
+import theme from '../styles/theme';
 
 type ComponentType = FC<{ children: ReactNode }>;
 
@@ -66,24 +66,27 @@ const App = ({
     }, []);
 
     return (
-        <ChakraProvider theme={theme}>
-            <PageHead
-                title="Stake CTSI"
-                description="Secure the Cartesi network and earn rewards"
-            />
-            <Fonts />
-            <FeatureFlagProvider>
-                <ENSDataProvider value={ensData}>
-                    <Web3Container>
-                        <GA4TrackerProvider>
-                            <ApolloContainer>
-                                <Component {...pageProps} />
-                            </ApolloContainer>
-                        </GA4TrackerProvider>
-                    </Web3Container>
-                </ENSDataProvider>
-            </FeatureFlagProvider>
-        </ChakraProvider>
+        <>
+            <ChakraProvider theme={theme}>
+                <PageHead
+                    title="Stake CTSI"
+                    description="Secure the Cartesi network and earn rewards"
+                />
+                <Fonts />
+                <FeatureFlagProvider>
+                    <ENSDataProvider value={ensData}>
+                        <Web3Container>
+                            <GA4TrackerProvider>
+                                <ApolloContainer>
+                                    <Component {...pageProps} />
+                                </ApolloContainer>
+                            </GA4TrackerProvider>
+                        </Web3Container>
+                    </ENSDataProvider>
+                </FeatureFlagProvider>
+            </ChakraProvider>
+            <SpeedInsights />
+        </>
     );
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6159,6 +6159,11 @@
   resolved "https://registry.yarnpkg.com/@use-it/event-listener/-/event-listener-0.1.7.tgz#443a9b6df87f2f2961b74d42997ce723a7078623"
   integrity sha512-hgfExDzUU9uTRTPDCpw2s9jWTxcxmpJya3fK5ADpf5VDpSy8WYwY/kh28XE0tUcbsljeP8wfan48QvAQTSSa3Q==
 
+"@vercel/speed-insights@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@vercel/speed-insights/-/speed-insights-1.2.0.tgz#1656c3596d4ec02d93d301ca45944c1b9b245186"
+  integrity sha512-y9GVzrUJ2xmgtQlzFP2KhVRoCglwfRQgjyfY607aU0hh0Un6d0OUyrJkjuAlsV18qR4zfoFPs/BiIj9YDS6Wzw==
+
 "@vitest/browser@^3.0.7":
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/@vitest/browser/-/browser-3.0.7.tgz#1a40ff3eb9faeac2cf0de888bf6716dc612cbe01"


### PR DESCRIPTION
### Summary
The previous form of collecting speed analytics for the web application was deprecated. Now it is only possible through that @vercel/speed-insights package. 