### PR TITLE
feat: Update jotai to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
         "framer-motion": "10.13.0",
         "graphql": "15.6.0",
         "humanize-duration": "3.29.0",
-        "jotai": "1.7.0",
+        "jotai": "2.12.4",
         "jquery": "3.6.0",
         "lodash": "4.17.21",
         "luxon": "2.5.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14540,10 +14540,10 @@ joi@17.9.1:
     "@sideway/formula" "^3.0.1"
     "@sideway/pinpoint" "^2.0.0"
 
-jotai@1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/jotai/-/jotai-1.7.0.tgz#b22e4cb995270a0215564990eeacc804025eb557"
-  integrity sha512-4KuvLcPuzzd86P2YHgU6cnu07HMDXgSyuakMNT/j+ihTN2cTjzmg9sCq59f4H9ImPe02wgdYBJ6LKIySNEAD/w==
+jotai@2.12.4:
+  version "2.12.4"
+  resolved "https://registry.yarnpkg.com/jotai/-/jotai-2.12.4.tgz#f6b38e71ce5a2ddd6c5741ee5a6d3abb79e274f8"
+  integrity sha512-eFXLJol4oOLM8BS1+QV+XwaYQITG8n1tatBCFl4F5HE3zR5j2WIK8QpMt7VJIYmlogNUZfvB7wjwLoVk+umB9Q==
 
 jquery@3.6.0:
   version "3.6.0"


### PR DESCRIPTION
I upgraded Jotai to its latest version. The [migration](https://jotai.org/docs/guides/migrating-to-v2-api#migration-guides) from v1 to v2 has some breaking changes, however those don't affect us as we are just using `atom` and `useAtom` functionality from the library.